### PR TITLE
Bug 1310272 - Include Adjust Support

### DIFF
--- a/Blockzilla.xcodeproj/project.pbxproj
+++ b/Blockzilla.xcodeproj/project.pbxproj
@@ -72,6 +72,12 @@
 		D3E2C96F1DA3093D00DEBE3D /* BrowserToolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3E2C96E1DA3093D00DEBE3D /* BrowserToolbar.swift */; };
 		D3E2C98A1DA47D5300DEBE3D /* Browser.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3E2C9891DA47D5300DEBE3D /* Browser.swift */; };
 		D3E3CA7D1DA827AD0079C94B /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3E3CA7C1DA827AD0079C94B /* HomeView.swift */; };
+		E47F9AE21DB927FD00A93285 /* AdjustSdk.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E47F9AE11DB927FD00A93285 /* AdjustSdk.framework */; };
+		E47F9AE71DB929D800A93285 /* AdSupport.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E47F9AE51DB929D800A93285 /* AdSupport.framework */; };
+		E47F9AE81DB929D800A93285 /* iAd.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E47F9AE61DB929D800A93285 /* iAd.framework */; };
+		E47F9AEA1DB9329D00A93285 /* Adjust-Focus.plist in Resources */ = {isa = PBXBuildFile; fileRef = E47F9AE91DB9329D00A93285 /* Adjust-Focus.plist */; };
+		E47F9AEC1DB9333200A93285 /* Adjust-Klar.plist in Resources */ = {isa = PBXBuildFile; fileRef = E47F9AEB1DB9333200A93285 /* Adjust-Klar.plist */; };
+		E47F9AEE1DB9338600A93285 /* AdjustIntegration.swift in Sources */ = {isa = PBXBuildFile; fileRef = E47F9AED1DB9338600A93285 /* AdjustIntegration.swift */; };
 		E4BF2DD71BACE8CA00DA9D68 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4BF2DD61BACE8CA00DA9D68 /* AppDelegate.swift */; };
 		E4BF2DDE1BACE8CA00DA9D68 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = E4BF2DDD1BACE8CA00DA9D68 /* Assets.xcassets */; };
 		E4BF2DF11BACE92400DA9D68 /* ActionRequestHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4BF2DF01BACE92400DA9D68 /* ActionRequestHandler.swift */; };
@@ -179,6 +185,12 @@
 		D3E3CA7C1DA827AD0079C94B /* HomeView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
 		D3E3CA801DA83FAF0079C94B /* Blockzilla.entitlements */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.entitlements; path = Blockzilla.entitlements; sourceTree = "<group>"; };
 		D3E3CA811DA83FAF0079C94B /* BlockzillaEnterprise.entitlements */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.entitlements; path = BlockzillaEnterprise.entitlements; sourceTree = "<group>"; };
+		E47F9AE11DB927FD00A93285 /* AdjustSdk.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AdjustSdk.framework; path = Carthage/Build/iOS/AdjustSdk.framework; sourceTree = "<group>"; };
+		E47F9AE51DB929D800A93285 /* AdSupport.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AdSupport.framework; path = System/Library/Frameworks/AdSupport.framework; sourceTree = SDKROOT; };
+		E47F9AE61DB929D800A93285 /* iAd.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = iAd.framework; path = System/Library/Frameworks/iAd.framework; sourceTree = SDKROOT; };
+		E47F9AE91DB9329D00A93285 /* Adjust-Focus.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "Adjust-Focus.plist"; sourceTree = "<group>"; };
+		E47F9AEB1DB9333200A93285 /* Adjust-Klar.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "Adjust-Klar.plist"; sourceTree = "<group>"; };
+		E47F9AED1DB9338600A93285 /* AdjustIntegration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AdjustIntegration.swift; sourceTree = "<group>"; };
 		E4BF2DD31BACE8CA00DA9D68 /* Klar.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Klar.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		E4BF2DD61BACE8CA00DA9D68 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		E4BF2DDD1BACE8CA00DA9D68 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -196,6 +208,9 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E47F9AE71DB929D800A93285 /* AdSupport.framework in Frameworks */,
+				E47F9AE81DB929D800A93285 /* iAd.framework in Frameworks */,
+				E47F9AE21DB927FD00A93285 /* AdjustSdk.framework in Frameworks */,
 				D38D693D1C471A98003EF211 /* GCDWebServers.framework in Frameworks */,
 				D38D693E1C471A98003EF211 /* SnapKit.framework in Frameworks */,
 				2916D1F85A9DE2CF4997BA3B /* BuddyBuildSDK.framework in Frameworks */,
@@ -275,6 +290,9 @@
 		D77FE464056F274978E025ED /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				E47F9AE51DB929D800A93285 /* AdSupport.framework */,
+				E47F9AE61DB929D800A93285 /* iAd.framework */,
+				E47F9AE11DB927FD00A93285 /* AdjustSdk.framework */,
 				885AD5B8AB73EB0DA9702536 /* BuddyBuildSDK.framework */,
 				29B90C056305836CB297FF79 /* AssetsLibrary.framework */,
 				F4C4943B406FCA9B74B4E186 /* CoreText.framework */,
@@ -320,6 +338,9 @@
 				D30179C51BCD78E1009AD388 /* Blockzilla-Bridging-Header.h */,
 				E4BF2DE21BACE8CA00DA9D68 /* Info.plist */,
 				E4BF2E131BAE324400DA9D68 /* LaunchScreen.storyboard */,
+				E47F9AED1DB9338600A93285 /* AdjustIntegration.swift */,
+				E47F9AE91DB9329D00A93285 /* Adjust-Focus.plist */,
+				E47F9AEB1DB9333200A93285 /* Adjust-Klar.plist */,
 				D3BFCB501BD1559300AD22D1 /* AboutContentViewController.swift */,
 				D30179C21BCC6F65009AD388 /* AboutViewController.swift */,
 				E4BF2DD61BACE8CA00DA9D68 /* AppDelegate.swift */,
@@ -473,6 +494,7 @@
 				6616A36F1BD17EFA00C7E493 /* style.css in Resources */,
 				D3E2C8FE1D9F17AC00DEBE3D /* disconnect-social.json in Resources */,
 				D3B3232D1BD16A0F00B0EEE4 /* gpl.html in Resources */,
+				E47F9AEA1DB9329D00A93285 /* Adjust-Focus.plist in Resources */,
 				D343DCC21C44356500D7EEE8 /* Localizable.strings in Resources */,
 				D3E2C8FB1D9F17AC00DEBE3D /* disconnect-advertising.json in Resources */,
 				D362D2AB1C4EAF940041980A /* rights-Focus.html in Resources */,
@@ -480,6 +502,7 @@
 				D3E2C8FD1D9F17AC00DEBE3D /* disconnect-content.json in Resources */,
 				E4BF2E141BAE324400DA9D68 /* LaunchScreen.storyboard in Resources */,
 				D3BFCB5B1BD15CD000AD22D1 /* rights-Klar.html in Resources */,
+				E47F9AEC1DB9333200A93285 /* Adjust-Klar.plist in Resources */,
 				D3426AEF1DB846BB0016DA5A /* topdomains.txt in Resources */,
 				D3E2C8FF1D9F17AC00DEBE3D /* web-fonts.json in Resources */,
 			);
@@ -510,6 +533,7 @@
 			inputPaths = (
 				"$(SRCROOT)/Carthage/Build/iOS/SnapKit.framework",
 				"$(SRCROOT)/Carthage/Build/iOS/GCDWebServers.framework",
+				"$(SRCROOT)/Carthage/Build/iOS/AdjustSdk.framework",
 			);
 			outputPaths = (
 			);
@@ -541,6 +565,7 @@
 				D3E2C9691DA3024800DEBE3D /* InsetButton.swift in Sources */,
 				D33A1AB11BC48FAC0003D929 /* SettingsViewController.swift in Sources */,
 				D36C1BAA1DB02EBB0073C1AB /* OpenUtils.swift in Sources */,
+				E47F9AEE1DB9338600A93285 /* AdjustIntegration.swift in Sources */,
 				D392881D1BC5CF180016A9A0 /* UIColorExtensions.swift in Sources */,
 				D3E3CA7D1DA827AD0079C94B /* HomeView.swift in Sources */,
 				D34E70331DA8736300BABDCC /* AutocompleteTextField.swift in Sources */,

--- a/Blockzilla/Adjust-Focus.plist
+++ b/Blockzilla/Adjust-Focus.plist
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>AppToken</key>
+	<string>XXX</string>
+	<key>Events</key>
+	<dict>
+		<key>Browse</key>
+		<string>hjuag8</string>
+		<key>Search</key>
+		<string>jf1b59</string>
+		<key>Clear</key>
+		<string>hy183e</string>
+		<key>OpenInFirefox</key>
+		<string>t7m1ru</string>
+		<key>OpenInSafari</key>
+		<string>ns4a3y</string>
+		<key>EnableBlockAds</key>
+		<string>1pmsby</string>
+		<key>DisableBlockAds</key>
+		<string>34xb7g</string>
+		<key>EnableBlockAnalytics</key>
+		<string>oimjge</string>
+		<key>DisableBlockAnalytics</key>
+		<string>pppabq</string>
+		<key>EnableBlockFonts</key>
+		<string>1zb5ah</string>
+		<key>DisableBlockFonts</key>
+		<string>nfi1np</string>
+		<key>EnableBlockOther</key>
+		<string>fr308r</string>
+		<key>DisableBlockOther</key>
+		<string>vp5tjk</string>
+		<key>EnableBlockSocial</key>
+		<string>9l4fiy</string>
+		<key>DisableBlockSocial</key>
+		<string>ha6nkv</string>
+		<key>EnableSafariIntegration</key>
+		<string>ec8kb7</string>
+		<key>DisableSafariIntegration</key>
+		<string>i0zoki</string>
+	</dict>
+</dict>
+</plist>

--- a/Blockzilla/Adjust-Klar.plist
+++ b/Blockzilla/Adjust-Klar.plist
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>AppToken</key>
+	<string>XXX</string>
+	<key>Events</key>
+	<dict>
+		<key>Browse</key>
+		<string>58bwsk</string>
+		<key>Search</key>
+		<string>pxtu4v</string>
+		<key>Clear</key>
+		<string>n9hwgu</string>
+		<key>OpenInFirefox</key>
+		<string>usp0gb</string>
+		<key>OpenInSafari</key>
+		<string>5elufs</string>
+		<key>EnableBlockAds</key>
+		<string>frnano</string>
+		<key>DisableBlockAds</key>
+		<string>uqm3k4</string>
+		<key>EnableBlockAnalytics</key>
+		<string>au3px7</string>
+		<key>DisableBlockAnalytics</key>
+		<string>4t3lka</string>
+		<key>EnableBlockFonts</key>
+		<string>5fbqr5</string>
+		<key>DisableBlockFonts</key>
+		<string>oymwmb</string>
+		<key>EnableBlockOther</key>
+		<string>tz19iu</string>
+		<key>DisableBlockOther</key>
+		<string>vzlgmg</string>
+		<key>EnableBlockSocial</key>
+		<string>6ddntz</string>
+		<key>DisableBlockSocial</key>
+		<string>ohnn42</string>
+		<key>EnableSafariIntegration</key>
+		<string>w67hjo</string>
+		<key>DisableSafariIntegration</key>
+		<string>8a1gtl</string>
+	</dict>
+</dict>
+</plist>

--- a/Blockzilla/AdjustIntegration.swift
+++ b/Blockzilla/AdjustIntegration.swift
@@ -1,0 +1,94 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+import AdjustSdk
+
+enum AdjustEventName: String {
+    case browse = "Browse"
+    case search = "Search"
+    case clear = "Clear"
+    case openFirefox = "OpenInFirefox"
+    case openSafari = "OpenInSafari"
+    case enableSafariIntegration = "EnableSafariIntegration"
+    case disableSafariIntegration = "DisableSafariIntegration"
+    case enableBlockAds = "EnableBlockAds"
+    case disableBlockAds = "DisableBlockAds"
+    case enableBlockAnalytics = "EnableBlockAnalytics"
+    case disableBlockAnalytics = "DisableBlockAnalytics"
+    case enableBlockSocial = "EnableBlockSocial"
+    case disableBlockSocial = "DisableBlockSocial"
+    case enableBlockOther = "EnableBlockOther"
+    case disableBlockOther = "DisableBlockOther"
+    case enableBlockFonts = "EnableBlockFonts"
+    case disableBlockFonts = "DisableBlockFonts"
+}
+
+private let AdjustAppTokenKey = "AppToken"
+private let AdjustEventsKey = "Events"
+
+private enum AdjustEnvironment: String {
+    case sandbox = "sandbox"
+    case production = "production"
+}
+
+private struct AdjustSettings {
+    var appToken: String
+    var environment: AdjustEnvironment
+    var events: [AdjustEventName: String]
+
+    init?(contentsOf url: URL) {
+        guard let config = NSDictionary(contentsOf: url), let appToken = config.object(forKey: AdjustAppTokenKey) as? String, let events = config.object(forKey: AdjustEventsKey) as? [String: String] else {
+            return nil
+        }
+
+        var eventMappings = [AdjustEventName: String]()
+        for (name, token) in events {
+            guard let eventName = AdjustEventName(rawValue: name) else {
+                assertionFailure("Event <\(name)> from settings plist not found in enum")
+                continue
+            }
+            eventMappings[eventName] = token
+        }
+
+        self.appToken = appToken
+        #if RELEASE
+            self.environment = AdjustEnvironment.production
+        #else
+            self.environment = AdjustEnvironment.sandbox
+        #endif
+        self.events = eventMappings
+    }
+}
+
+class AdjustIntegration {
+    fileprivate static var adjustSettings: AdjustSettings?
+
+    public static func applicationDidFinishLaunching() {
+        if let url = Bundle.main.url(forResource: "Adjust-\(AppInfo.ProductName)", withExtension: "plist"), let settings = AdjustSettings(contentsOf: url) {
+            adjustSettings = settings
+
+            let config = ADJConfig(appToken: settings.appToken, environment: settings.environment.rawValue)
+            #if DEBUG
+                config?.logLevel = ADJLogLevelDebug
+            #endif
+
+            Adjust.appDidLaunch(config)
+        }
+    }
+
+    public static func disable() {
+        Adjust.setEnabled(false)
+    }
+
+    public static func track(eventName: AdjustEventName) {
+        if Adjust.isEnabled() {
+            guard let settings = adjustSettings, let eventToken = settings.events[eventName] else {
+                assertionFailure("Adjust not initialized or event <\(eventName.rawValue)> was not found in the settings")
+                return
+            }
+            Adjust.trackEvent(ADJEvent(eventToken: eventToken))
+        }
+    }
+}

--- a/Blockzilla/AppDelegate.swift
+++ b/Blockzilla/AppDelegate.swift
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import UIKit
+import AdjustSdk
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
@@ -12,6 +13,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
         BuddyBuildSDK.setup()
+
+        // Always initialize Adjust, otherwise the SDK is in a bad state. We disable it
+        // immediately so that no data is collected or sent.
+        AdjustIntegration.applicationDidFinishLaunching()
+        if !Settings.getToggle(.sendAnonymousUsageData) {
+            AdjustIntegration.disable()
+        }
 
         // Re-register the blocking lists at startup in case they've changed.
         Utils.reloadSafariContentBlocker()

--- a/Blockzilla/BrowserViewController.swift
+++ b/Blockzilla/BrowserViewController.swift
@@ -162,6 +162,8 @@ class BrowserViewController: UIViewController {
         })
 
         browserToolbar.animateHidden(true, duration: UIConstants.layout.toolbarFadeAnimationDuration)
+
+        AdjustIntegration.track(eventName: .clear)
     }
 
     fileprivate func showSettings() {
@@ -181,6 +183,12 @@ class BrowserViewController: UIViewController {
         }
 
         browser.loadRequest(URLRequest(url: url))
+
+        if searchEngine.isSearchURL(url: url) {
+            AdjustIntegration.track(eventName: .search)
+        } else {
+            AdjustIntegration.track(eventName: .browse)
+        }
     }
 }
 
@@ -307,6 +315,7 @@ extension BrowserViewController: OverlayViewDelegate {
     func overlayView(_ overlayView: OverlayView, didSearchForQuery query: String) {
         if let url = searchEngine.urlForQuery(query) {
             submit(url: url)
+            AdjustIntegration.track(eventName: .search)
         }
         urlBar.dismiss()
     }

--- a/Blockzilla/OpenUtils.swift
+++ b/Blockzilla/OpenUtils.swift
@@ -23,8 +23,11 @@ class OpenUtils {
     /// Opens the URL in Firefox, if Firefox is available.
     /// Otherwise, the URL is opened in Safari.
     static func openInExternalBrowser(url: URL) {
-        if !openInFirefox(url: url) {
+        if openInFirefox(url: url) {
+            AdjustIntegration.track(eventName: .openFirefox)
+        } else {
             openInSafari(url: url)
+            AdjustIntegration.track(eventName: .openSafari)
         }
     }
 }

--- a/Blockzilla/SearchEngine.swift
+++ b/Blockzilla/SearchEngine.swift
@@ -16,4 +16,8 @@ class SearchEngine {
 
         return url
     }
+
+    func isSearchURL(url: URL) -> Bool {
+        return url.host == "duckduckgo.com"
+    }
 }

--- a/Blockzilla/SettingsViewController.swift
+++ b/Blockzilla/SettingsViewController.swift
@@ -22,6 +22,7 @@ class SettingsViewController: UIViewController, UITableViewDataSource, UITableVi
         BlockerToggle(label: UIConstants.strings.labelBlockSocial, setting: SettingsToggle.blockSocial),
         BlockerToggle(label: UIConstants.strings.labelBlockOther, setting: SettingsToggle.blockOther, subtitle: UIConstants.strings.subtitleBlockOther),
         BlockerToggle(label: UIConstants.strings.labelBlockFonts, setting: SettingsToggle.blockFonts),
+        BlockerToggle(label: UIConstants.strings.labelSendAnonymousUsageData, setting: SettingsToggle.sendAnonymousUsageData, subtitle: UIConstants.strings.subtitleSendAnonymousUsageData),
     ]
 
     /// Used to calculate cell heights.
@@ -106,7 +107,8 @@ class SettingsViewController: UIViewController, UITableViewDataSource, UITableVi
             }
         case 1: fallthrough
         case 2: fallthrough
-        case 3:
+        case 3: fallthrough
+        case 4:
             let toggle = toggleForIndexPath(indexPath)
             cell.textLabel?.text = toggle.label
             cell.textLabel?.numberOfLines = 0
@@ -130,6 +132,7 @@ class SettingsViewController: UIViewController, UITableViewDataSource, UITableVi
         case 1: return 1 // Integration.
         case 2: return 4 // Privacy.
         case 3: return 1 // Performance.
+        case 4: return 1 // Support
         default:
             assertionFailure("Invalid section")
             return 0
@@ -137,7 +140,7 @@ class SettingsViewController: UIViewController, UITableViewDataSource, UITableVi
     }
 
     func numberOfSections(in tableView: UITableView) -> Int {
-        return 4
+        return 5
     }
 
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
@@ -175,6 +178,7 @@ class SettingsViewController: UIViewController, UITableViewDataSource, UITableVi
         case 1: labelText = UIConstants.strings.toggleSectionIntegration
         case 2: labelText = UIConstants.strings.toggleSectionPrivacy
         case 3: labelText = UIConstants.strings.toggleSectionPerformance
+        case 4: labelText = UIConstants.strings.toggleSectionSupport
         default: return nil
         }
 
@@ -203,7 +207,8 @@ class SettingsViewController: UIViewController, UITableViewDataSource, UITableVi
         switch section {
         case 1: fallthrough
         case 2: fallthrough
-        case 3: return 30
+        case 3: fallthrough
+        case 4: return 30
         default: return 0
         }
     }
@@ -236,6 +241,23 @@ class SettingsViewController: UIViewController, UITableViewDataSource, UITableVi
         let toggle = toggles.filter { $0.toggle == sender }.first!
 
         func updateSetting() {
+            switch toggle.setting {
+            case .safari:
+                AdjustIntegration.track(eventName: sender.isOn ? .enableSafariIntegration : .disableSafariIntegration)
+            case .blockAds:
+                AdjustIntegration.track(eventName: sender.isOn ? .enableBlockAds : .disableBlockAds)
+            case .blockAnalytics:
+                AdjustIntegration.track(eventName: sender.isOn ? .enableBlockAnalytics : .disableBlockAnalytics)
+            case .blockSocial:
+                AdjustIntegration.track(eventName: sender.isOn ? .enableBlockSocial : .disableBlockSocial)
+            case .blockOther:
+                AdjustIntegration.track(eventName: sender.isOn ? .enableBlockOther : .disableBlockOther)
+            case .blockFonts:
+                AdjustIntegration.track(eventName: sender.isOn ? .enableBlockFonts : .disableBlockFonts)
+            default:
+                break
+            }
+
             Settings.set(sender.isOn, forToggle: toggle.setting)
             Utils.reloadSafariContentBlocker()
             LocalContentBlocker.reload()

--- a/Blockzilla/UIConstants.swift
+++ b/Blockzilla/UIConstants.swift
@@ -95,5 +95,8 @@ struct UIConstants {
         static let toggleSafari = NSLocalizedString("Settings.toggleSafari", value: "Safari", comment: "Safari toggle label on settings screen")
         static let urlBarCancel = NSLocalizedString("URL.cancelLabel", value: "Cancel", comment: "Label for cancel button shown when entering a URL or search")
         static let urlTextPlaceholder = NSLocalizedString("URL.placeholderText", value: "Search or enter address", comment: "Placeholder text shown in the URL bar before the user navigates to a page")
+        static let toggleSectionSupport = NSLocalizedString("Settings.supportSectionLabel", value: "SUPPORT", comment: "Section label for support toggles")
+        static let labelSendAnonymousUsageData = NSLocalizedString("Settings.toggleSendAnonymousUsageData", value: "Send anonymous usage data", comment: "Label for Send Anonymous Usage Data toggle on main screen")
+        static let subtitleSendAnonymousUsageData = NSLocalizedString("Settings.toggleSendAnonymousUsageDataSubtitle", value: "More info…", comment: "Subtitle for Send Anonymous Usage Data toggle on main screen")
     }
 }

--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,3 @@
 github "swisspol/GCDWebServer" ~> 3.3.3
 github "SnapKit/SnapKit"       ~> 3.0.1
+github "adjust/ios_sdk"        ~> 4.10.2

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,3 @@
 github "swisspol/GCDWebServer" "3.3.3"
 github "SnapKit/SnapKit" "3.1.1"
+github "adjust/ios_sdk" "v4.10.2"

--- a/Shared/Settings.swift
+++ b/Shared/Settings.swift
@@ -11,6 +11,7 @@ enum SettingsToggle: String {
     case blockOther = "BlockOther"
     case blockFonts = "BlockFonts"
     case safari = "Safari"
+    case sendAnonymousUsageData = "SendAnonymousUsageData"
 }
 
 struct Settings {
@@ -27,6 +28,7 @@ struct Settings {
             case .blockOther: return false
             case .blockFonts: return false
             case .safari: return true
+            case .sendAnonymousUsageData: return true
         }
     }
 

--- a/buddybuild_prebuild.sh
+++ b/buddybuild_prebuild.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# This script inserts the private Adjust tokens into the two property lists that
+# contain the Adjust settings for both Focus and Klar. It depends on two environment
+# variables to be set in BuddyBuild: ADJUST_TOKEN_FOCUS and ADJUST_TOKEN_KLAR.
+
+if [ -f "$BUDDYBUILD_WORKSPACE/Blockzilla/Adjust-Focus.plist" ]; then
+    /usr/libexec/PlistBuddy -c "Set AppToken $ADJUST_TOKEN_FOCUS" "$BUDDYBUILD_WORKSPACE/Blockzilla/Adjust-Focus.plist"
+fi
+
+if [ -f "$BUDDYBUILD_WORKSPACE/Blockzilla/Adjust-Klar.plist" ]; then
+    /usr/libexec/PlistBuddy -c "Set AppToken $ADJUST_TOKEN_KLAR" "$BUDDYBUILD_WORKSPACE/Blockzilla/Adjust-Klar.plist"
+fi
+


### PR DESCRIPTION
This patch introduces Adjust support in Focus. It has three parts:

* The Adjust SDK is initialized in `applicationDidFinishLaunching` - This gives us basic install and session statistics.
* Most common user actions are annotated with `AdjustIntegration.track(event:)` so that we know what options people are preferring and what actions are used most in the app.
* There is a new setting that lets people opt out of Adjust completely

