### PR TITLE
Bug 1310272 - Include Adjust Support - Followup Fix

### DIFF
--- a/Blockzilla/AdjustIntegration.swift
+++ b/Blockzilla/AdjustIntegration.swift
@@ -53,10 +53,10 @@ private struct AdjustSettings {
         }
 
         self.appToken = appToken
-        #if RELEASE
-            self.environment = AdjustEnvironment.production
-        #else
+        #if DEBUG
             self.environment = AdjustEnvironment.sandbox
+        #else
+            self.environment = AdjustEnvironment.release
         #endif
         self.events = eventMappings
     }

--- a/Blockzilla/AdjustIntegration.swift
+++ b/Blockzilla/AdjustIntegration.swift
@@ -56,7 +56,7 @@ private struct AdjustSettings {
         #if DEBUG
             self.environment = AdjustEnvironment.sandbox
         #else
-            self.environment = AdjustEnvironment.release
+            self.environment = AdjustEnvironment.production
         #endif
         self.events = eventMappings
     }


### PR DESCRIPTION
This patch inverses the `RELEASE` check logic. The reason is that the `RELEASE` flag is never set. Instead it is better to inverse it and check for `DEBUG` instead.