### PR TITLE
Bug 1314989 - We incorrectly recognize Focus vs Klar in product specific code

### DIFF
--- a/Blockzilla/AboutViewController.swift
+++ b/Blockzilla/AboutViewController.swift
@@ -8,7 +8,7 @@ import UIKit
 class AboutViewController: UIViewController, UITableViewDataSource, UITableViewDelegate, AboutHeaderViewDelegate {
     fileprivate let tableView = UITableView()
     fileprivate let headerView = AboutHeaderView()
-    fileprivate let supportPath = (AppInfo.ProductName == "Focus") ? "en-US/kb/focus" : "products/klar"
+    fileprivate let supportPath = AppInfo.isFocus ? "en-US/kb/focus" : "products/klar"
 
     override func viewDidLoad() {
         view.backgroundColor = UIConstants.colors.background

--- a/Blockzilla/AdjustIntegration.swift
+++ b/Blockzilla/AdjustIntegration.swift
@@ -66,7 +66,7 @@ class AdjustIntegration {
     fileprivate static var adjustSettings: AdjustSettings?
 
     public static func applicationDidFinishLaunching() {
-        if let url = Bundle.main.url(forResource: "Adjust-\(AppInfo.ProductName)", withExtension: "plist"), let settings = AdjustSettings(contentsOf: url) {
+        if let url = Bundle.main.url(forResource: AppInfo.isFocus ? "Adjust-Focus" : "Adjust-Klar", withExtension: "plist"), let settings = AdjustSettings(contentsOf: url) {
             adjustSettings = settings
 
             let config = ADJConfig(appToken: settings.appToken, environment: settings.environment.rawValue)

--- a/Shared/AppInfo.swift
+++ b/Shared/AppInfo.swift
@@ -46,4 +46,8 @@ class AppInfo {
     static var LanguageCode: String {
         return Bundle.main.preferredLocalizations.first!
     }
+
+    static var isFocus: Bool {
+        return AppInfo.ProductName.contains("Focus")
+    }
 }


### PR DESCRIPTION
This patch introduces `AppInfo.isFocus` so that we can more reliably do *Focus* or *Klar* specific things in the code. We are still checking the product name, but now that logic is at least isolated in one place.