### PR TITLE
Bug 1316930 - Do not include BuddyBuild in release builds

### DIFF
--- a/Blockzilla.xcodeproj/project.pbxproj
+++ b/Blockzilla.xcodeproj/project.pbxproj
@@ -8,7 +8,6 @@
 
 /* Begin PBXBuildFile section */
 		2825C3665AB14081B262F767 /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1D051AC1857A0EEEBB833D15 /* SystemConfiguration.framework */; };
-		2916D1F85A9DE2CF4997BA3B /* BuddyBuildSDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 885AD5B8AB73EB0DA9702536 /* BuddyBuildSDK.framework */; };
 		2B36326E97D2E67E9C684B4B /* CoreTelephony.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 80D9AA926EFBD788739486EB /* CoreTelephony.framework */; };
 		2F2F84BCF076B21DE42D1F29 /* CoreMedia.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C652A61E213D254A86DF5736 /* CoreMedia.framework */; };
 		34056D10515852F370C83A01 /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AAB8E622E994545108473554 /* QuartzCore.framework */; };
@@ -228,7 +227,6 @@
 				E47F9AE21DB927FD00A93285 /* AdjustSdk.framework in Frameworks */,
 				D38D693D1C471A98003EF211 /* GCDWebServers.framework in Frameworks */,
 				D38D693E1C471A98003EF211 /* SnapKit.framework in Frameworks */,
-				2916D1F85A9DE2CF4997BA3B /* BuddyBuildSDK.framework in Frameworks */,
 				4285B8E0671F40DA543A2E58 /* AssetsLibrary.framework in Frameworks */,
 				A57245250F88CCA4993E55B2 /* CoreText.framework in Frameworks */,
 				2B36326E97D2E67E9C684B4B /* CoreTelephony.framework in Frameworks */,
@@ -710,8 +708,13 @@
 				);
 				INFOPLIST_FILE = Blockzilla/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				OTHER_LDFLAGS = (
+					"-framework",
+					BuddyBuildSDK,
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = org.mozilla.ios.Focus.enterprise;
 				PRODUCT_NAME = "Firefox Focus";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = BUDDYBUILD;
 				SWIFT_OBJC_BRIDGING_HEADER = "Blockzilla-Bridging-Header.h";
 				SWIFT_VERSION = 3.0;
 				VALID_ARCHS = arm64;
@@ -797,8 +800,13 @@
 				);
 				INFOPLIST_FILE = Blockzilla/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				OTHER_LDFLAGS = (
+					"-framework",
+					BuddyBuildSDK,
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = org.mozilla.ios.Focus;
 				PRODUCT_NAME = "Firefox Focus";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG BUDDYBUILD";
 				SWIFT_OBJC_BRIDGING_HEADER = "Blockzilla-Bridging-Header.h";
 				SWIFT_VERSION = 3.0;
 				VALID_ARCHS = arm64;
@@ -1008,8 +1016,13 @@
 				);
 				INFOPLIST_FILE = Blockzilla/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				OTHER_LDFLAGS = (
+					"-framework",
+					BuddyBuildSDK,
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = org.mozilla.ios.Klar;
 				PRODUCT_NAME = "Firefox Klar";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG BUDDYBUILD";
 				SWIFT_OBJC_BRIDGING_HEADER = "Blockzilla-Bridging-Header.h";
 				SWIFT_VERSION = 3.0;
 				VALID_ARCHS = arm64;

--- a/Blockzilla/AppDelegate.swift
+++ b/Blockzilla/AppDelegate.swift
@@ -14,7 +14,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     private static let prefIntroVersion = 2
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
-        BuddyBuildSDK.setup()
+        #if BUDDYBUILD
+            BuddyBuildSDK.setup()
+        #endif
 
         // Always initialize Adjust, otherwise the SDK is in a bad state. We disable it
         // immediately so that no data is collected or sent.


### PR DESCRIPTION
This patch does the following:

It introduces a conditional compilation option for Swift (`SWIFT_ACTIVE_COMPILATION_CONDITIONS`) named `BUDDYBUILD`. This option is set for the *FocusDebug*, *KlarDebug* and *FocusEnterprise* build configurations. Only in the *Blockzilla* target.

It removes the `BuddyBuildSDK.framework` from all targets. We keep it in the project so that it can be found, but by default it is not part of any target.

It adds `-framework BuddyBuildSDK` to the `OTHER_LDFLAGS` build setting for the *FocusDebug*, *KlarDebug* and *FocusEnterprise* build configurations.

In `application(didFinishLaunchingWithOptions:)` it condtionally includes the code to setup BuddyBuild in , based on the `BUDDYBUILD` compilation option. If it is not set then the code is not included at all and no frameworks are referenced.

> (This patch started as *Only enable BuddyBuild for DEBUG builds*. But that implies that we would also have to change the *FocusEnterprise*, which is currently not a DEBUG build.  I think is a bit too scary, since we also need to send that build out to early testers. So nothing changed regarding build settings. Just a new `BUDDYBUILD` compile option to specify per build config if it should ship with BB or not.)
