### PR TITLE
Change url_filter() to only match subdomains of resource

### DIFF
--- a/build-disconnect.py
+++ b/build-disconnect.py
@@ -11,7 +11,7 @@ import urlparse
 
 
 def url_filter(resource):
-    return "^https?://(.+\\.)?" + resource.replace(".", "\\.")
+    return "^https?://([^/]+\\.)?" + resource.replace(".", "\\.")
 
 
 def unless_domain(properties):


### PR DESCRIPTION
Proposed fix for https://bugzilla.mozilla.org/show_bug.cgi?id=1317067

This avoids the filter regex for domain `foo.com` from matching URLs like `http://bar.com/baz.foo.com`. 

Tested regex on Swift sandbox and verified that Blocklists/*.json are generated correctly.