### PR TITLE
Bug 1318291 - Crash because of missing usage descriptions

### DIFF
--- a/Blockzilla.xcodeproj/project.pbxproj
+++ b/Blockzilla.xcodeproj/project.pbxproj
@@ -82,6 +82,7 @@
 		D3E3CA7D1DA827AD0079C94B /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3E3CA7C1DA827AD0079C94B /* HomeView.swift */; };
 		E40AFB101DC9014700DA5651 /* UserAgent.swift in Sources */ = {isa = PBXBuildFile; fileRef = E40AFB0F1DC9014700DA5651 /* UserAgent.swift */; };
 		E40AFB141DC939FF00DA5651 /* SupportUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = E40AFB131DC939FF00DA5651 /* SupportUtils.swift */; };
+		E40AFC741DDDE96D00DA5651 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = E40AFC761DDDE96D00DA5651 /* InfoPlist.strings */; };
 		E47F9AE21DB927FD00A93285 /* AdjustSdk.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E47F9AE11DB927FD00A93285 /* AdjustSdk.framework */; };
 		E47F9AE71DB929D800A93285 /* AdSupport.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E47F9AE51DB929D800A93285 /* AdSupport.framework */; };
 		E47F9AE81DB929D800A93285 /* iAd.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E47F9AE61DB929D800A93285 /* iAd.framework */; };
@@ -214,6 +215,8 @@
 		D3E3CA811DA83FAF0079C94B /* BlockzillaEnterprise.entitlements */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.entitlements; path = BlockzillaEnterprise.entitlements; sourceTree = "<group>"; };
 		E40AFB0F1DC9014700DA5651 /* UserAgent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserAgent.swift; sourceTree = "<group>"; };
 		E40AFB131DC939FF00DA5651 /* SupportUtils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SupportUtils.swift; sourceTree = "<group>"; };
+		E40AFC771DDDE97600DA5651 /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		E40AFC791DDDE98300DA5651 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		E47F9AE11DB927FD00A93285 /* AdjustSdk.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AdjustSdk.framework; path = Carthage/Build/iOS/AdjustSdk.framework; sourceTree = "<group>"; };
 		E47F9AE51DB929D800A93285 /* AdSupport.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AdSupport.framework; path = System/Library/Frameworks/AdSupport.framework; sourceTree = SDKROOT; };
 		E47F9AE61DB929D800A93285 /* iAd.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = iAd.framework; path = System/Library/Frameworks/iAd.framework; sourceTree = SDKROOT; };
@@ -396,6 +399,7 @@
 				E47F9AE91DB9329D00A93285 /* Adjust-Focus.plist */,
 				E47F9AEB1DB9333200A93285 /* Adjust-Klar.plist */,
 				E4BF2DE21BACE8CA00DA9D68 /* Info.plist */,
+				E40AFC761DDDE96D00DA5651 /* InfoPlist.strings */,
 				D3C047BC1DCBD8ED00402FFB /* SearchEngines.plist */,
 				D38EDB971DCA8CBD00E28196 /* splash.png */,
 				D38EDB951DCA8A9400E28196 /* LaunchScreen.storyboard */,
@@ -560,6 +564,7 @@
 			knownRegions = (
 				en,
 				Base,
+				de,
 			);
 			mainGroup = E4BF2DCA1BACE8CA00DA9D68;
 			productRefGroup = E4BF2DD41BACE8CA00DA9D68 /* Products */;
@@ -594,6 +599,7 @@
 				D3DA778C1DC2C60E009C114E /* errorPage.html in Resources */,
 				E47F9AEA1DB9329D00A93285 /* Adjust-Focus.plist in Resources */,
 				D38EDB961DCA8A9400E28196 /* LaunchScreen.storyboard in Resources */,
+				E40AFC741DDDE96D00DA5651 /* InfoPlist.strings in Resources */,
 				D343DCC21C44356500D7EEE8 /* Localizable.strings in Resources */,
 				D3E2C8FB1D9F17AC00DEBE3D /* disconnect-advertising.json in Resources */,
 				D362D2AB1C4EAF940041980A /* rights-focus.html in Resources */,
@@ -735,6 +741,15 @@
 				D362D26A1C47326A0041980A /* en */,
 			);
 			name = Localizable.strings;
+			sourceTree = "<group>";
+		};
+		E40AFC761DDDE96D00DA5651 /* InfoPlist.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				E40AFC771DDDE97600DA5651 /* de */,
+				E40AFC791DDDE98300DA5651 /* en */,
+			);
+			name = InfoPlist.strings;
 			sourceTree = "<group>";
 		};
 /* End PBXVariantGroup section */

--- a/Blockzilla/Info.plist
+++ b/Blockzilla/Info.plist
@@ -46,5 +46,13 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>Websites you visit may request your location.</string>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>This lets you save and upload photos.</string>
+	<key>NSCameraUsageDescription</key>
+	<string>This lets you take and upload photos.</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>This lets you take and upload videos.</string>
 </dict>
 </plist>

--- a/Blockzilla/de.lproj/InfoPlist.strings
+++ b/Blockzilla/de.lproj/InfoPlist.strings
@@ -1,0 +1,8 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+NSLocationWhenInUseUsageDescription = "Von Ihnen besuchte Websites können Ihren Standort abfragen.";
+NSPhotoLibraryUsageDescription = "Hiermit können Sie Fotos speichern und hochladen.";
+NSCameraUsageDescription = "Hiermit können Sie Fotos machen und hochladen.";
+NSMicrophoneUsageDescription = "Hiermit können Sie Videos aufnehmen und hochladen.";

--- a/Blockzilla/en.lproj/InfoPlist.strings
+++ b/Blockzilla/en.lproj/InfoPlist.strings
@@ -1,0 +1,8 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+NSLocationWhenInUseUsageDescription = "Websites you visit may request your location.";
+NSPhotoLibraryUsageDescription = "This lets you save and upload photos.";
+NSCameraUsageDescription = "This lets you take and upload photos.";
+NSMicrophoneUsageDescription = "This lets you take and upload videos.";


### PR DESCRIPTION
This adds the following usage descriptions to the app:

• `NSLocationWhenInUseUsageDescription`
• `NSPhotoLibraryUsageDescription`
• `NSCameraUsageDescription`
• `NSMicrophoneUsageDescription`

Without these, the app will crash when a website asks for your location or media access.

I also added German strings, copied from Firefox for iOS.
