### PR TITLE
Bug 1324816 Automate Snapshots

### DIFF
--- a/Blockzilla.xcodeproj/project.pbxproj
+++ b/Blockzilla.xcodeproj/project.pbxproj
@@ -63,8 +63,6 @@
 		D3BFCB511BD1559300AD22D1 /* AboutContentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3BFCB501BD1559300AD22D1 /* AboutContentViewController.swift */; };
 		D3BFCB5B1BD15CD000AD22D1 /* rights-klar.html in Resources */ = {isa = PBXBuildFile; fileRef = D3BFCB5A1BD15CD000AD22D1 /* rights-klar.html */; };
 		D3C047BD1DCBD8ED00402FFB /* SearchEngines.plist in Resources */ = {isa = PBXBuildFile; fileRef = D3C047BC1DCBD8ED00402FFB /* SearchEngines.plist */; };
-		D3C70C5F1DDE785300CEE458 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = D3C70C611DDE785300CEE458 /* InfoPlist.strings */; };
-		D3C70C641DDE785400CEE458 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = D3C70C661DDE785400CEE458 /* InfoPlist.strings */; };
 		D3CD375B1DD3B51900468250 /* FirstRunViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3CD375A1DD3B51900468250 /* FirstRunViewController.swift */; };
 		D3DA77851DC2C307009C114E /* ErrorPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3DA77841DC2C307009C114E /* ErrorPage.swift */; };
 		D3DA778C1DC2C60E009C114E /* errorPage.html in Resources */ = {isa = PBXBuildFile; fileRef = D3DA778B1DC2C60E009C114E /* errorPage.html */; };
@@ -95,6 +93,8 @@
 		E40AFB101DC9014700DA5651 /* UserAgent.swift in Sources */ = {isa = PBXBuildFile; fileRef = E40AFB0F1DC9014700DA5651 /* UserAgent.swift */; };
 		E40AFB141DC939FF00DA5651 /* SupportUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = E40AFB131DC939FF00DA5651 /* SupportUtils.swift */; };
 		E40AFC741DDDE96D00DA5651 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = E40AFC761DDDE96D00DA5651 /* InfoPlist.strings */; };
+		E44A346A1E0A18C100BFD777 /* SnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E44A34691E0A18C100BFD777 /* SnapshotTests.swift */; };
+		E44A34761E0A198000BFD777 /* SnapshotHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = E44A34751E0A198000BFD777 /* SnapshotHelper.swift */; };
 		E47F9AE21DB927FD00A93285 /* AdjustSdk.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E47F9AE11DB927FD00A93285 /* AdjustSdk.framework */; };
 		E47F9AE71DB929D800A93285 /* AdSupport.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E47F9AE51DB929D800A93285 /* AdSupport.framework */; };
 		E47F9AE81DB929D800A93285 /* iAd.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E47F9AE61DB929D800A93285 /* iAd.framework */; };
@@ -115,6 +115,13 @@
 
 /* Begin PBXContainerItemProxy section */
 		0BA39A881DD2B8E4005F970A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = E4BF2DCB1BACE8CA00DA9D68 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = E4BF2DD21BACE8CA00DA9D68;
+			remoteInfo = Blockzilla;
+		};
+		E44A346C1E0A18C100BFD777 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = E4BF2DCB1BACE8CA00DA9D68 /* Project object */;
 			proxyType = 1;
@@ -203,8 +210,6 @@
 		D3BFCB501BD1559300AD22D1 /* AboutContentViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AboutContentViewController.swift; sourceTree = "<group>"; };
 		D3BFCB5A1BD15CD000AD22D1 /* rights-klar.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "rights-klar.html"; sourceTree = "<group>"; };
 		D3C047BC1DCBD8ED00402FFB /* SearchEngines.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; name = SearchEngines.plist; path = Search/SearchEngines.plist; sourceTree = SOURCE_ROOT; };
-		D3C70C601DDE785300CEE458 /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/InfoPlist.strings; sourceTree = "<group>"; };
-		D3C70C651DDE785400CEE458 /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		D3C70C671DDE795300CEE458 /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		D3C70C711DDFCA4800CEE458 /* Klar.entitlements */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.entitlements; path = Klar.entitlements; sourceTree = "<group>"; };
 		D3C70C721DDFCA7000CEE458 /* KlarEnterprise.entitlements */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.entitlements; path = KlarEnterprise.entitlements; sourceTree = "<group>"; };
@@ -235,6 +240,10 @@
 		E40AFB0F1DC9014700DA5651 /* UserAgent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserAgent.swift; sourceTree = "<group>"; };
 		E40AFB131DC939FF00DA5651 /* SupportUtils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SupportUtils.swift; sourceTree = "<group>"; };
 		E40AFC791DDDE98300DA5651 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		E44A34671E0A18C100BFD777 /* ScreenshotTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; name = ScreenshotTests.xctest; path = SnapshotTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		E44A34691E0A18C100BFD777 /* SnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnapshotTests.swift; sourceTree = "<group>"; };
+		E44A346B1E0A18C100BFD777 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		E44A34751E0A198000BFD777 /* SnapshotHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SnapshotHelper.swift; sourceTree = "<group>"; };
 		E47F9AE11DB927FD00A93285 /* AdjustSdk.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AdjustSdk.framework; path = Carthage/Build/iOS/AdjustSdk.framework; sourceTree = "<group>"; };
 		E47F9AE51DB929D800A93285 /* AdSupport.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AdSupport.framework; path = System/Library/Frameworks/AdSupport.framework; sourceTree = SDKROOT; };
 		E47F9AE61DB929D800A93285 /* iAd.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = iAd.framework; path = System/Library/Frameworks/iAd.framework; sourceTree = SDKROOT; };
@@ -258,6 +267,13 @@
 
 /* Begin PBXFrameworksBuildPhase section */
 		0BA39A801DD2B8E4005F970A /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E44A34641E0A18C100BFD777 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -299,7 +315,6 @@
 			isa = PBXGroup;
 			children = (
 				0B70C1621DE6128900CEF7E0 /* WebsiteMemoryTest.swift */,
-				D3C70C611DDE785300CEE458 /* InfoPlist.strings */,
 				0BBBED3F1DD3821600F9C565 /* Utils */,
 				0BA39A851DD2B8E4005F970A /* WebsiteAccessTest.swift */,
 				0BBBED421DD3B78300F9C565 /* SettingAppearanceTest.swift */,
@@ -391,6 +406,17 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
+		E44A34681E0A18C100BFD777 /* SnapshotTests */ = {
+			isa = PBXGroup;
+			children = (
+				E44A34691E0A18C100BFD777 /* SnapshotTests.swift */,
+				E44A34751E0A198000BFD777 /* SnapshotHelper.swift */,
+				E44A346B1E0A18C100BFD777 /* Info.plist */,
+			);
+			name = SnapshotTests;
+			path = ScreenshotTests;
+			sourceTree = "<group>";
+		};
 		E4BF2DCA1BACE8CA00DA9D68 = {
 			isa = PBXGroup;
 			children = (
@@ -406,6 +432,7 @@
 				D33A1A391BC476D40003D929 /* Shared */,
 				D30179D31BCDA5EE009AD388 /* ThirdParty */,
 				0BA39A841DD2B8E4005F970A /* XCUITest */,
+				E44A34681E0A18C100BFD777 /* SnapshotTests */,
 			);
 			sourceTree = "<group>";
 		};
@@ -415,6 +442,7 @@
 				E4BF2DD31BACE8CA00DA9D68 /* Klar.app */,
 				E4BF2DEC1BACE92400DA9D68 /* ContentBlocker.appex */,
 				0BA39A831DD2B8E4005F970A /* XCUITest.xctest */,
+				E44A34671E0A18C100BFD777 /* ScreenshotTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -488,7 +516,6 @@
 		E4BF2DED1BACE92400DA9D68 /* ContentBlocker */ = {
 			isa = PBXGroup;
 			children = (
-				D3C70C661DDE785400CEE458 /* InfoPlist.strings */,
 				D3BBC9EC1D7F81CB00D1751B /* enabled-detector.json */,
 				E4BF2DF21BACE92400DA9D68 /* Info.plist */,
 				E4BF2DF01BACE92400DA9D68 /* ActionRequestHandler.swift */,
@@ -515,6 +542,24 @@
 			name = XCUITest;
 			productName = XCUITest;
 			productReference = 0BA39A831DD2B8E4005F970A /* XCUITest.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
+		E44A34661E0A18C100BFD777 /* SnapshotTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = E44A34741E0A18C100BFD777 /* Build configuration list for PBXNativeTarget "SnapshotTests" */;
+			buildPhases = (
+				E44A34631E0A18C100BFD777 /* Sources */,
+				E44A34641E0A18C100BFD777 /* Frameworks */,
+				E44A34651E0A18C100BFD777 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				E44A346D1E0A18C100BFD777 /* PBXTargetDependency */,
+			);
+			name = SnapshotTests;
+			productName = ScreenshotTests;
+			productReference = E44A34671E0A18C100BFD777 /* ScreenshotTests.xctest */;
 			productType = "com.apple.product-type.bundle.ui-testing";
 		};
 		E4BF2DD21BACE8CA00DA9D68 /* Blockzilla */ = {
@@ -561,12 +606,18 @@
 		E4BF2DCB1BACE8CA00DA9D68 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 0810;
+				LastSwiftUpdateCheck = 0820;
 				LastUpgradeCheck = 0800;
 				ORGANIZATIONNAME = Mozilla;
 				TargetAttributes = {
 					0BA39A821DD2B8E4005F970A = {
 						CreatedOnToolsVersion = 8.1;
+						DevelopmentTeam = 43AQ936H96;
+						ProvisioningStyle = Automatic;
+						TestTargetID = E4BF2DD21BACE8CA00DA9D68;
+					};
+					E44A34661E0A18C100BFD777 = {
+						CreatedOnToolsVersion = 8.2.1;
 						DevelopmentTeam = 43AQ936H96;
 						ProvisioningStyle = Automatic;
 						TestTargetID = E4BF2DD21BACE8CA00DA9D68;
@@ -612,6 +663,7 @@
 				E4BF2DD21BACE8CA00DA9D68 /* Blockzilla */,
 				E4BF2DEB1BACE92400DA9D68 /* ContentBlocker */,
 				0BA39A821DD2B8E4005F970A /* XCUITest */,
+				E44A34661E0A18C100BFD777 /* SnapshotTests */,
 			);
 		};
 /* End PBXProject section */
@@ -621,7 +673,13 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D3C70C5F1DDE785300CEE458 /* InfoPlist.strings in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E44A34651E0A18C100BFD777 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -660,7 +718,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				D32817251BD0689800185845 /* disconnect-social.json in Resources */,
-				D3C70C641DDE785400CEE458 /* InfoPlist.strings in Resources */,
 				D32817231BD0689800185845 /* disconnect-analytics.json in Resources */,
 				D3BBC9ED1D7F81CB00D1751B /* enabled-detector.json in Resources */,
 				D32817221BD0689800185845 /* disconnect-advertising.json in Resources */,
@@ -715,6 +772,15 @@
 				0BBBED411DD3823C00F9C565 /* BaseTestCase.swift in Sources */,
 				0B70C1631DE6128900CEF7E0 /* WebsiteMemoryTest.swift in Sources */,
 				0BA39A861DD2B8E4005F970A /* WebsiteAccessTest.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E44A34631E0A18C100BFD777 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E44A346A1E0A18C100BFD777 /* SnapshotTests.swift in Sources */,
+				E44A34761E0A198000BFD777 /* SnapshotHelper.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -794,6 +860,11 @@
 			target = E4BF2DD21BACE8CA00DA9D68 /* Blockzilla */;
 			targetProxy = 0BA39A881DD2B8E4005F970A /* PBXContainerItemProxy */;
 		};
+		E44A346D1E0A18C100BFD777 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = E4BF2DD21BACE8CA00DA9D68 /* Blockzilla */;
+			targetProxy = E44A346C1E0A18C100BFD777 /* PBXContainerItemProxy */;
+		};
 		E4BF2DF41BACE92400DA9D68 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = E4BF2DEB1BACE92400DA9D68 /* ContentBlocker */;
@@ -809,22 +880,6 @@
 				D362D26A1C47326A0041980A /* en */,
 			);
 			name = Localizable.strings;
-			sourceTree = "<group>";
-		};
-		D3C70C611DDE785300CEE458 /* InfoPlist.strings */ = {
-			isa = PBXVariantGroup;
-			children = (
-				D3C70C601DDE785300CEE458 /* de */,
-			);
-			name = InfoPlist.strings;
-			sourceTree = "<group>";
-		};
-		D3C70C661DDE785400CEE458 /* InfoPlist.strings */ = {
-			isa = PBXVariantGroup;
-			children = (
-				D3C70C651DDE785400CEE458 /* de */,
-			);
-			name = InfoPlist.strings;
 			sourceTree = "<group>";
 		};
 		E40AFC761DDDE96D00DA5651 /* InfoPlist.strings */ = {
@@ -1491,6 +1546,307 @@
 			};
 			name = FocusRelease;
 		};
+		E44A346E1E0A18C100BFD777 /* KlarDebug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEVELOPMENT_TEAM = 43AQ936H96;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				INFOPLIST_FILE = ScreenshotTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.2;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = org.mozilla.ios.blockzilla.ScreenshotTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
+				TEST_TARGET_NAME = Blockzilla;
+			};
+			name = KlarDebug;
+		};
+		E44A346F1E0A18C100BFD777 /* FocusDebug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = 43AQ936H96;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				INFOPLIST_FILE = ScreenshotTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.2;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = org.mozilla.ios.blockzilla.ScreenshotTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 3.0;
+				TEST_TARGET_NAME = Blockzilla;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = FocusDebug;
+		};
+		E44A34701E0A18C100BFD777 /* KlarRelease */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = 43AQ936H96;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				INFOPLIST_FILE = ScreenshotTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.2;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = org.mozilla.ios.blockzilla.ScreenshotTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 3.0;
+				TEST_TARGET_NAME = Blockzilla;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = KlarRelease;
+		};
+		E44A34711E0A18C100BFD777 /* FocusRelease */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = 43AQ936H96;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				INFOPLIST_FILE = ScreenshotTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.2;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = org.mozilla.ios.blockzilla.ScreenshotTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 3.0;
+				TEST_TARGET_NAME = Blockzilla;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = FocusRelease;
+		};
+		E44A34721E0A18C100BFD777 /* FocusEnterprise */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = 43AQ936H96;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				INFOPLIST_FILE = ScreenshotTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.2;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = org.mozilla.ios.blockzilla.ScreenshotTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 3.0;
+				TEST_TARGET_NAME = Blockzilla;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = FocusEnterprise;
+		};
+		E44A34731E0A18C100BFD777 /* KlarEnterprise */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = 43AQ936H96;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				INFOPLIST_FILE = ScreenshotTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.2;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = org.mozilla.ios.blockzilla.ScreenshotTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 3.0;
+				TEST_TARGET_NAME = Blockzilla;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = KlarEnterprise;
+		};
 		E4BF2DE31BACE8CA00DA9D68 /* KlarDebug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -1678,6 +2034,19 @@
 				0BA39A8E1DD2B8E4005F970A /* FocusRelease */,
 				0BA39A8F1DD2B8E4005F970A /* FocusEnterprise */,
 				D3C70C701DDFC48100CEE458 /* KlarEnterprise */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = FocusRelease;
+		};
+		E44A34741E0A18C100BFD777 /* Build configuration list for PBXNativeTarget "SnapshotTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E44A346E1E0A18C100BFD777 /* KlarDebug */,
+				E44A346F1E0A18C100BFD777 /* FocusDebug */,
+				E44A34701E0A18C100BFD777 /* KlarRelease */,
+				E44A34711E0A18C100BFD777 /* FocusRelease */,
+				E44A34721E0A18C100BFD777 /* FocusEnterprise */,
+				E44A34731E0A18C100BFD777 /* KlarEnterprise */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = FocusRelease;

--- a/Blockzilla.xcodeproj/xcshareddata/xcschemes/Focus.xcscheme
+++ b/Blockzilla.xcodeproj/xcshareddata/xcschemes/Focus.xcscheme
@@ -38,6 +38,16 @@
                ReferencedContainer = "container:Blockzilla.xcodeproj">
             </BuildableReference>
          </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "E44A34661E0A18C100BFD777"
+               BuildableName = "SnapshotTests.xctest"
+               BlueprintName = "SnapshotTests"
+               ReferencedContainer = "container:Blockzilla.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
       <MacroExpansion>
          <BuildableReference

--- a/Blockzilla.xcodeproj/xcshareddata/xcschemes/FocusSnapshotTests.xcscheme
+++ b/Blockzilla.xcodeproj/xcshareddata/xcschemes/FocusSnapshotTests.xcscheme
@@ -23,21 +23,11 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
-      buildConfiguration = "KlarDebug"
+      buildConfiguration = "FocusDebug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "0BA39A821DD2B8E4005F970A"
-               BuildableName = "XCUITest.xctest"
-               BlueprintName = "XCUITest"
-               ReferencedContainer = "container:Blockzilla.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
          <TestableReference
             skipped = "NO">
             <BuildableReference
@@ -62,7 +52,7 @@
       </AdditionalOptions>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "KlarDebug"
+      buildConfiguration = "FocusDebug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
@@ -70,8 +60,7 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
-      allowLocationSimulation = "YES"
-      language = "de">
+      allowLocationSimulation = "YES">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">
          <BuildableReference
@@ -86,7 +75,7 @@
       </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
-      buildConfiguration = "KlarRelease"
+      buildConfiguration = "FocusRelease"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
@@ -103,10 +92,10 @@
       </BuildableProductRunnable>
    </ProfileAction>
    <AnalyzeAction
-      buildConfiguration = "KlarDebug">
+      buildConfiguration = "FocusDebug">
    </AnalyzeAction>
    <ArchiveAction
-      buildConfiguration = "KlarRelease"
+      buildConfiguration = "FocusRelease"
       revealArchiveInOrganizer = "YES">
    </ArchiveAction>
 </Scheme>

--- a/Blockzilla.xcodeproj/xcshareddata/xcschemes/KlarSnapshotTests.xcscheme
+++ b/Blockzilla.xcodeproj/xcshareddata/xcschemes/KlarSnapshotTests.xcscheme
@@ -32,16 +32,6 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "0BA39A821DD2B8E4005F970A"
-               BuildableName = "XCUITest.xctest"
-               BlueprintName = "XCUITest"
-               ReferencedContainer = "container:Blockzilla.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
                BlueprintIdentifier = "E44A34661E0A18C100BFD777"
                BuildableName = "SnapshotTests.xctest"
                BlueprintName = "SnapshotTests"

--- a/Blockzilla/BrowserToolset.swift
+++ b/Blockzilla/BrowserToolset.swift
@@ -50,6 +50,7 @@ class BrowserToolset {
         sendButton.contentEdgeInsets = UIConstants.layout.toolbarButtonInsets
         sendButton.addTarget(self, action: #selector(didPressSend), for: .touchUpInside)
         sendButton.accessibilityLabel = UIConstants.strings.browserShare
+        sendButton.accessibilityIdentifier = "BrowserToolset.sendButton"
     }
 
     var canGoBack: Bool = false {

--- a/Blockzilla/FirstRunViewController.swift
+++ b/Blockzilla/FirstRunViewController.swift
@@ -43,6 +43,7 @@ class FirstRunViewController: UIViewController {
         button.layer.borderColor = UIConstants.colors.firstRunButtonBorder.cgColor
         button.layer.cornerRadius = 3
         button.addTarget(self, action: #selector(didPressDismiss), for: .touchUpInside)
+        button.accessibilityIdentifier = "FirstRunViewController.button"
         view.addSubview(button)
 
         let margin = 8

--- a/Blockzilla/HomeView.swift
+++ b/Blockzilla/HomeView.swift
@@ -39,6 +39,7 @@ class HomeView: UIView {
         settingsButton.contentEdgeInsets = UIEdgeInsets(top: 20, left: 20, bottom: 20, right: 20)
         settingsButton.addTarget(self, action: #selector(didPressSettings), for: .touchUpInside)
         settingsButton.accessibilityLabel = UIConstants.strings.browserSettings
+        settingsButton.accessibilityIdentifier = "HomeView.settingsButton"
         addSubview(settingsButton)
 
         textLogo.snp.makeConstraints { make in

--- a/Blockzilla/SettingsViewController.swift
+++ b/Blockzilla/SettingsViewController.swift
@@ -55,6 +55,7 @@ class SettingsViewController: UIViewController, UITableViewDataSource, UITableVi
         navigationBar.titleTextAttributes = [NSForegroundColorAttributeName: UIConstants.colors.navigationTitle]
 
         let aboutButton = UIBarButtonItem(title: UIConstants.strings.aboutTitle, style: .plain, target: self, action: #selector(aboutClicked))
+        aboutButton.accessibilityIdentifier = "SettingsViewController.aboutButton"
         navigationItem.rightBarButtonItem = aboutButton
 
         view.addSubview(tableView)
@@ -121,6 +122,7 @@ class SettingsViewController: UIViewController, UITableViewDataSource, UITableVi
             cell = UITableViewCell(style: .subtitle, reuseIdentifier: "searchCell")
             cell.textLabel?.text = searchEngineManager.activeEngine.name
             cell.accessoryType = .disclosureIndicator
+            cell.accessibilityIdentifier = "SettingsViewController.searchCell"
         default:
             cell = UITableViewCell(style: .subtitle, reuseIdentifier: "toggleCell")
             let toggle = toggleForIndexPath(indexPath)
@@ -356,5 +358,6 @@ private class BlockerToggle {
         self.label = label
         self.setting = setting
         self.subtitle = subtitle
+        toggle.accessibilityIdentifier = "BlockerToggle.\(setting.rawValue)"
     }
 }

--- a/Blockzilla/Toast.swift
+++ b/Blockzilla/Toast.swift
@@ -27,6 +27,7 @@ class Toast {
         label.textColor = UIConstants.colors.toastText
         label.font = UIConstants.fonts.toast
         label.numberOfLines = 0
+        label.accessibilityIdentifier = "Toast.label"
         toast.addSubview(label)
 
         toast.snp.makeConstraints { make in

--- a/Blockzilla/URLBar.swift
+++ b/Blockzilla/URLBar.swift
@@ -85,6 +85,7 @@ class URLBar: UIView {
         urlText.setContentHuggingPriority(1000, for: .vertical)
         urlText.autocompleteDelegate = self
         urlText.source = domainCompletion
+        urlText.accessibilityIdentifier = "URLBar.urlText"
         textAndLockContainer.addSubview(urlText)
 
         cancelButton.isHidden = true
@@ -108,6 +109,7 @@ class URLBar: UIView {
         deleteButton.setContentHuggingPriority(1000, for: .horizontal)
         deleteButton.setContentCompressionResistancePriority(1000, for: .horizontal)
         deleteButton.addTarget(self, action: #selector(didPressDelete), for: .touchUpInside)
+        deleteButton.accessibilityIdentifier = "URLBar.deleteButton"
         addSubview(deleteButton)
 
         let buttonContainer = UIView()
@@ -129,6 +131,7 @@ class URLBar: UIView {
         activateButton.setTitleColor(UIConstants.colors.urlTextPlaceholder, for: .normal)
         activateButton.titleEdgeInsets = UIEdgeInsetsMake(0, UIConstants.layout.urlBarWidthInset, 0, UIConstants.layout.urlBarWidthInset)
         activateButton.addTarget(self, action: #selector(didPressActivate), for: .touchUpInside)
+        activateButton.accessibilityIdentifier = "URLBar.activateButton"
         addSubview(activateButton)
 
         progressBar.isHidden = true

--- a/ContentBlocker/de.lproj/InfoPlist.strings
+++ b/ContentBlocker/de.lproj/InfoPlist.strings
@@ -1,9 +1,0 @@
-/* (No Commment) */
-"CFBundleDisplayName" = "$(PRODUCT_NAME)";
-
-/* (No Commment) */
-"CFBundleName" = "$(PRODUCT_NAME)";
-
-/* (No Commment) */
-"CFBundleShortVersionString" = "2.0";
-

--- a/ScreenshotTests/Info.plist
+++ b/ScreenshotTests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/ScreenshotTests/SnapshotHelper.swift
+++ b/ScreenshotTests/SnapshotHelper.swift
@@ -1,0 +1,138 @@
+//
+//  SnapshotHelper.swift
+//  Example
+//
+//  Created by Felix Krause on 10/8/15.
+//  Copyright © 2015 Felix Krause. All rights reserved.
+//
+
+import Foundation
+import XCTest
+
+var deviceLanguage = ""
+var locale = ""
+
+@available(*, deprecated, message: "use setupSnapshot: instead")
+func setLanguage(_ app: XCUIApplication) {
+    setupSnapshot(app)
+}
+
+func setupSnapshot(_ app: XCUIApplication) {
+    Snapshot.setupSnapshot(app)
+}
+
+func snapshot(_ name: String, waitForLoadingIndicator: Bool = true) {
+    Snapshot.snapshot(name, waitForLoadingIndicator: waitForLoadingIndicator)
+}
+
+open class Snapshot: NSObject {
+
+    open class func setupSnapshot(_ app: XCUIApplication) {
+        setLanguage(app)
+        setLocale(app)
+        setLaunchArguments(app)
+    }
+
+    class func setLanguage(_ app: XCUIApplication) {
+        guard let prefix = pathPrefix() else {
+            return
+        }
+
+        let path = prefix.appendingPathComponent("language.txt")
+
+        do {
+            let trimCharacterSet = CharacterSet.whitespacesAndNewlines
+            deviceLanguage = try NSString(contentsOfFile: path, encoding: String.Encoding.utf8.rawValue).trimmingCharacters(in: trimCharacterSet) as String
+            app.launchArguments += ["-AppleLanguages", "(\(deviceLanguage))"]
+        } catch {
+            print("Couldn't detect/set language...")
+        }
+    }
+
+    class func setLocale(_ app: XCUIApplication) {
+        guard let prefix = pathPrefix() else {
+            return
+        }
+
+        let path = prefix.appendingPathComponent("locale.txt")
+
+        do {
+            let trimCharacterSet = CharacterSet.whitespacesAndNewlines
+            locale = try NSString(contentsOfFile: path, encoding: String.Encoding.utf8.rawValue).trimmingCharacters(in: trimCharacterSet) as String
+        } catch {
+            print("Couldn't detect/set locale...")
+        }
+        if locale.isEmpty {
+            locale = Locale(identifier: deviceLanguage).identifier
+        }
+        app.launchArguments += ["-AppleLocale", "\"\(locale)\""]
+    }
+
+    class func setLaunchArguments(_ app: XCUIApplication) {
+        guard let prefix = pathPrefix() else {
+            return
+        }
+
+        let path = prefix.appendingPathComponent("snapshot-launch_arguments.txt")
+        app.launchArguments += ["-FASTLANE_SNAPSHOT", "YES", "-ui_testing"]
+
+        do {
+            let launchArguments = try NSString(contentsOfFile: path, encoding: String.Encoding.utf8.rawValue) as String
+            let regex = try NSRegularExpression(pattern: "(\\\".+?\\\"|\\S+)", options: [])
+            let matches = regex.matches(in: launchArguments, options: [], range: NSRange(location:0, length:launchArguments.characters.count))
+            let results = matches.map { result -> String in
+                (launchArguments as NSString).substring(with: result.range)
+            }
+            app.launchArguments += results
+        } catch {
+            print("Couldn't detect/set launch_arguments...")
+        }
+    }
+
+    open class func snapshot(_ name: String, waitForLoadingIndicator: Bool = true) {
+        if waitForLoadingIndicator {
+            waitForLoadingIndicatorToDisappear()
+        }
+
+        print("snapshot: \(name)") // more information about this, check out https://github.com/fastlane/fastlane/tree/master/snapshot#how-does-it-work
+
+        sleep(1) // Waiting for the animation to be finished (kind of)
+
+        #if os(tvOS)
+            XCUIApplication().childrenMatchingType(.Browser).count
+        #else
+            XCUIDevice.shared().orientation = .unknown
+        #endif
+    }
+
+    class func waitForLoadingIndicatorToDisappear() {
+        #if os(tvOS)
+            return
+        #endif
+
+        let query = XCUIApplication().statusBars.children(matching: .other).element(boundBy: 1).children(matching: .other)
+
+        while (0..<query.count).map({ query.element(boundBy: $0) }).contains(where: { $0.isLoadingIndicator }) {
+            sleep(1)
+            print("Waiting for loading indicator to disappear...")
+        }
+    }
+
+    class func pathPrefix() -> NSString? {
+        if let path = ProcessInfo().environment["SIMULATOR_HOST_HOME"] as NSString? {
+            return path.appendingPathComponent("Library/Caches/tools.fastlane") as NSString?
+        }
+        print("Couldn't find Snapshot configuration files at ~/Library/Caches/tools.fastlane")
+        return nil
+    }
+}
+
+extension XCUIElement {
+    var isLoadingIndicator: Bool {
+        return self.frame.size == CGSize(width: 10, height: 20)
+    }
+}
+
+// Please don't remove the lines below
+// They are used to detect outdated configuration files
+// SnapshotHelperVersion [1.2]

--- a/ScreenshotTests/SnapshotTests.swift
+++ b/ScreenshotTests/SnapshotTests.swift
@@ -1,0 +1,103 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import XCTest
+
+class SnapshotTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        continueAfterFailure = false
+        let app = XCUIApplication()
+        setupSnapshot(app)
+        app.launch()
+    }
+
+    func test01Screenshots() {
+        let app = XCUIApplication()
+        snapshot("00FirstRun")
+        app.buttons["FirstRunViewController.button"].tap()
+
+        snapshot("01Home")
+
+        app.buttons["URLBar.activateButton"].tap()
+        snapshot("02LocationBarEmptyState")
+        app.textFields["URLBar.urlText"].typeText("people-mozilla.org")
+        snapshot("03SearchFor")
+
+        app.typeText("\n")
+        waitForValueContains(element: app.textFields["URLBar.urlText"], value: "https://people-mozilla.org/")
+        snapshot("04EraseButton")
+
+        app.buttons["URLBar.deleteButton"].tap()
+        waitforExistence(element: app.staticTexts["Toast.label"])
+        snapshot("05YourBrowsingHistoryHasBeenErased")
+    }
+
+    func test02Settings() {
+        let app = XCUIApplication()
+        app.buttons["HomeView.settingsButton"].tap()
+        snapshot("06Settings")
+        app.swipeUp()
+        snapshot("07Settings")
+        app.swipeDown()
+        app.cells["SettingsViewController.searchCell"].tap()
+        snapshot("08SettingsSearchEngine")
+        app.navigationBars.element(boundBy: 0).buttons.element(boundBy: 0).tap()
+        app.swipeUp()
+        app.switches["BlockerToggle.BlockOther"].tap()
+        snapshot("09SettingsBlockOtherContentTrackers")
+    }
+
+    func test03About() {
+        let app = XCUIApplication()
+        app.buttons["HomeView.settingsButton"].tap()
+        app.buttons["SettingsViewController.aboutButton"].tap()
+        snapshot("10About")
+        app.swipeUp()
+        snapshot("11About")
+    }
+
+    func test04ShareMenu() {
+        let app = XCUIApplication()
+        app.buttons["URLBar.activateButton"].tap()
+        app.textFields["URLBar.urlText"].typeText("people-mozilla.org\n")
+        waitForValueContains(element: app.textFields["URLBar.urlText"], value: "https://people-mozilla.org/")
+        app.buttons["BrowserToolset.sendButton"].tap()
+        snapshot("12ShareMenu")
+    }
+
+    func test05SafariIntegration() {
+        let app = XCUIApplication()
+        app.buttons["HomeView.settingsButton"].tap()
+        app.tables.switches["BlockerToggle.Safari"].tap()
+        snapshot("13SafariIntegrationInstructions")
+    }
+
+    func waitForValueContains(element:XCUIElement, value:String, file: String = #file, line: UInt = #line) {
+        let predicateText = "value CONTAINS " + "'" + value + "'"
+        let valueCheck = NSPredicate(format: predicateText)
+
+        expectation(for: valueCheck, evaluatedWith: element, handler: nil)
+        waitForExpectations(timeout: 20) {(error) -> Void in
+            if (error != nil) {
+                let message = "Failed to find \(element) after 20 seconds."
+                self.recordFailure(withDescription: message,
+                                   inFile: file, atLine: line, expected: true)
+            }
+        }
+    }
+
+    func waitforExistence(element: XCUIElement, file: String = #file, line: UInt = #line) {
+        let exists = NSPredicate(format: "exists == true")
+
+        expectation(for: exists, evaluatedWith: element, handler: nil)
+        waitForExpectations(timeout: 20) {(error) -> Void in
+            if (error != nil) {
+                let message = "Failed to find \(element) after 20 seconds."
+                self.recordFailure(withDescription: message,
+                                   inFile: file, atLine: line, expected: true)
+            }
+        }
+    }
+}

--- a/XCUITest/de.lproj/InfoPlist.strings
+++ b/XCUITest/de.lproj/InfoPlist.strings
@@ -1,6 +1,0 @@
-/* (No Commment) */
-"CFBundleName" = "$(PRODUCT_NAME)";
-
-/* (No Commment) */
-"CFBundleShortVersionString" = "1.0";
-

--- a/screenshots.sh
+++ b/screenshots.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+LANGUAGES="ar,az,cs,cy,de,en-US,es-CL,es-ES,fr,hu,id,it,ja,kab,pl,pt-BR,ru,ses,sk,sl,sv-SE,uk,zh-CN,zh-TW"
+
+TS=`date +%Y%m%d-%H%M`
+
+for PRODUCT in Focus Klar; do
+  for DEVICE in "iPhone 7 Plus" "iPhone 5s"; do
+    echo "Snapshotting $PRODUCT on $DEVICE"
+        DEVICEDIR="${DEVICE// /}"
+        mkdir -p "screenshots/$TS/$PRODUCT/$DEVICEDIR"
+        fastlane snapshot --project Blockzilla.xcodeproj --scheme "${PRODUCT}SnapshotTests" \
+          --erase_simulator --localize_simulator \
+          --devices "$DEVICE" \
+          --languages "$LANGUAGES" \
+          --output_directory "screenshots/$TS/$PRODUCT/$DEVICEDIR" \
+          --clear_previous_screenshots > "screenshots/$TS/$PRODUCT/$DEVICEDIR/snapshot.log" 2>&1
+  done
+done
+
+echo "You can now move these to pmo:"
+echo
+echo "  rsync -avh screenshots/$TS people.mozilla.org:~/public_html/focus/screenshots/"
+echo
+echo "They will be available at:"
+echo
+echo "  https://people-mozilla.org/~sarentz/focus/screenshots/$TS/"
+echo
+


### PR DESCRIPTION
This patch adds a SnapshotTests target with UI Automation Tests specifically to generate snapshots for localizers. The test walks through the whole app, exposing all strings. It also includes a `screenshots.sh` script to do this for both *Focus* and *Klar* on the *iPhone 5s* and *iPhone 7 Plus*.