### PR TITLE
Bug 1355124 - Replace existing SUMO links

### DIFF
--- a/Blockzilla.xcodeproj/project.pbxproj
+++ b/Blockzilla.xcodeproj/project.pbxproj
@@ -93,6 +93,7 @@
 		D3E54FD51DEFB25B003E1AFF /* SearchPlugins in Resources */ = {isa = PBXBuildFile; fileRef = D3E54FD41DEFB25B003E1AFF /* SearchPlugins */; };
 		D3E54FDE1DF0E0D7003E1AFF /* UIImageExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3E54FDD1DF0E0D6003E1AFF /* UIImageExtensions.swift */; };
 		D3E54FE01DF0E221003E1AFF /* SearchSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3E54FDF1DF0E221003E1AFF /* SearchSettingsViewController.swift */; };
+		E40A08711E99265E00E096EC /* SupportUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = E40AFB131DC939FF00DA5651 /* SupportUtils.swift */; };
 		E40AFB101DC9014700DA5651 /* UserAgent.swift in Sources */ = {isa = PBXBuildFile; fileRef = E40AFB0F1DC9014700DA5651 /* UserAgent.swift */; };
 		E40AFB141DC939FF00DA5651 /* SupportUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = E40AFB131DC939FF00DA5651 /* SupportUtils.swift */; };
 		E40AFC741DDDE96D00DA5651 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = E40AFC761DDDE96D00DA5651 /* InfoPlist.strings */; };
@@ -114,6 +115,8 @@
 		E4BF2DF51BACE92400DA9D68 /* ContentBlocker.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = E4BF2DEC1BACE92400DA9D68 /* ContentBlocker.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		E4BF2E111BAD8AC500DA9D68 /* Settings.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4BF2E101BAD8AC500DA9D68 /* Settings.swift */; };
 		E4BF2E121BAD8AC500DA9D68 /* Settings.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4BF2E101BAD8AC500DA9D68 /* Settings.swift */; };
+		E4F7F3F31E9C5D9200BAAB05 /* BlockzillaTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4F7F3F21E9C5D9200BAAB05 /* BlockzillaTests.swift */; };
+		E4F7F3FE1E9C5EAF00BAAB05 /* SupportUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = E40AFB131DC939FF00DA5651 /* SupportUtils.swift */; };
 		F805722F1DBEE504004339C1 /* WebCacheUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = F805722E1DBEE504004339C1 /* WebCacheUtils.swift */; };
 		F84AFE751DE77FE6005C4DD1 /* LaunchScreen.png in Resources */ = {isa = PBXBuildFile; fileRef = F84AFE721DE77FE6005C4DD1 /* LaunchScreen.png */; };
 		F84AFE761DE77FE6005C4DD1 /* LaunchScreen@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = F84AFE731DE77FE6005C4DD1 /* LaunchScreen@2x.png */; };
@@ -141,6 +144,13 @@
 			proxyType = 1;
 			remoteGlobalIDString = E4BF2DEB1BACE92400DA9D68;
 			remoteInfo = ContentBlocker;
+		};
+		E4F7F3F51E9C5D9200BAAB05 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = E4BF2DCB1BACE8CA00DA9D68 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = E4BF2DD21BACE8CA00DA9D68;
+			remoteInfo = Blockzilla;
 		};
 /* End PBXContainerItemProxy section */
 
@@ -500,6 +510,9 @@
 		E4D0AB881E300EFE00DFBEDA /* eo */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = eo; path = eo.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		E4D0AB891E300EFF00DFBEDA /* eo */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = eo; path = eo.lproj/Localizable.strings; sourceTree = "<group>"; };
 		E4D0AB8A1E300F0000DFBEDA /* eo */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = eo; path = eo.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		E4F7F3F01E9C5D9200BAAB05 /* BlockzillaTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BlockzillaTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		E4F7F3F21E9C5D9200BAAB05 /* BlockzillaTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockzillaTests.swift; sourceTree = "<group>"; };
+		E4F7F3F41E9C5D9200BAAB05 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		F4C4943B406FCA9B74B4E186 /* CoreText.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreText.framework; path = System/Library/Frameworks/CoreText.framework; sourceTree = SDKROOT; };
 		F805722E1DBEE504004339C1 /* WebCacheUtils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WebCacheUtils.swift; sourceTree = "<group>"; };
 		F84AFE721DE77FE6005C4DD1 /* LaunchScreen.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = LaunchScreen.png; sourceTree = "<group>"; };
@@ -544,6 +557,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		E4BF2DE91BACE92400DA9D68 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E4F7F3ED1E9C5D9200BAAB05 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -674,6 +694,7 @@
 				D3E2C9001D9F17C600DEBE3D /* Blocklists */,
 				E4BF2DD51BACE8CA00DA9D68 /* Blockzilla */,
 				E4BF2DED1BACE92400DA9D68 /* ContentBlocker */,
+				E4F7F3F11E9C5D9200BAAB05 /* BlockzillaTests */,
 				D77FE464056F274978E025ED /* Frameworks */,
 				E4BF2DD41BACE8CA00DA9D68 /* Products */,
 				D33A1A391BC476D40003D929 /* Shared */,
@@ -690,6 +711,7 @@
 				E4BF2DEC1BACE92400DA9D68 /* ContentBlocker.appex */,
 				0BA39A831DD2B8E4005F970A /* XCUITest.xctest */,
 				E44A34671E0A18C100BFD777 /* SnapshotTests.xctest */,
+				E4F7F3F01E9C5D9200BAAB05 /* BlockzillaTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -772,6 +794,15 @@
 			path = ContentBlocker;
 			sourceTree = "<group>";
 		};
+		E4F7F3F11E9C5D9200BAAB05 /* BlockzillaTests */ = {
+			isa = PBXGroup;
+			children = (
+				E4F7F3F21E9C5D9200BAAB05 /* BlockzillaTests.swift */,
+				E4F7F3F41E9C5D9200BAAB05 /* Info.plist */,
+			);
+			path = BlockzillaTests;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -849,13 +880,31 @@
 			productReference = E4BF2DEC1BACE92400DA9D68 /* ContentBlocker.appex */;
 			productType = "com.apple.product-type.app-extension";
 		};
+		E4F7F3EF1E9C5D9200BAAB05 /* BlockzillaTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = E4F7F3FD1E9C5D9200BAAB05 /* Build configuration list for PBXNativeTarget "BlockzillaTests" */;
+			buildPhases = (
+				E4F7F3EC1E9C5D9200BAAB05 /* Sources */,
+				E4F7F3ED1E9C5D9200BAAB05 /* Frameworks */,
+				E4F7F3EE1E9C5D9200BAAB05 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				E4F7F3F61E9C5D9200BAAB05 /* PBXTargetDependency */,
+			);
+			name = BlockzillaTests;
+			productName = BlockzillaTests;
+			productReference = E4F7F3F01E9C5D9200BAAB05 /* BlockzillaTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
 		E4BF2DCB1BACE8CA00DA9D68 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 0820;
+				LastSwiftUpdateCheck = 0830;
 				LastUpgradeCheck = 0800;
 				ORGANIZATIONNAME = Mozilla;
 				TargetAttributes = {
@@ -891,6 +940,11 @@
 							};
 						};
 					};
+					E4F7F3EF1E9C5D9200BAAB05 = {
+						CreatedOnToolsVersion = 8.3.1;
+						ProvisioningStyle = Manual;
+						TestTargetID = E4BF2DD21BACE8CA00DA9D68;
+					};
 				};
 			};
 			buildConfigurationList = E4BF2DCE1BACE8CA00DA9D68 /* Build configuration list for PBXProject "Blockzilla" */;
@@ -911,6 +965,7 @@
 				E4BF2DEB1BACE92400DA9D68 /* ContentBlocker */,
 				0BA39A821DD2B8E4005F970A /* XCUITest */,
 				E44A34661E0A18C100BFD777 /* SnapshotTests */,
+				E4F7F3EF1E9C5D9200BAAB05 /* BlockzillaTests */,
 			);
 		};
 /* End PBXProject section */
@@ -973,6 +1028,13 @@
 				D32817221BD0689800185845 /* disconnect-advertising.json in Resources */,
 				D32817241BD0689800185845 /* disconnect-content.json in Resources */,
 				D3B323521BD1A7EE00B0EEE4 /* web-fonts.json in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E4F7F3EE1E9C5D9200BAAB05 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1103,6 +1165,16 @@
 				D3A6605B1DAF0904002BA72A /* AppInfo.swift in Sources */,
 				E4BF2DF11BACE92400DA9D68 /* ActionRequestHandler.swift in Sources */,
 				D3A6605A1DAF08FA002BA72A /* Utils.swift in Sources */,
+				E40A08711E99265E00E096EC /* SupportUtils.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E4F7F3EC1E9C5D9200BAAB05 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E4F7F3F31E9C5D9200BAAB05 /* BlockzillaTests.swift in Sources */,
+				E4F7F3FE1E9C5EAF00BAAB05 /* SupportUtils.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1123,6 +1195,11 @@
 			isa = PBXTargetDependency;
 			target = E4BF2DEB1BACE92400DA9D68 /* ContentBlocker */;
 			targetProxy = E4BF2DF31BACE92400DA9D68 /* PBXContainerItemProxy */;
+		};
+		E4F7F3F61E9C5D9200BAAB05 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = E4BF2DD21BACE8CA00DA9D68 /* Blockzilla */;
+			targetProxy = E4F7F3F51E9C5D9200BAAB05 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -2542,6 +2619,325 @@
 			};
 			name = KlarRelease;
 		};
+		E4F7F3F71E9C5D9200BAAB05 /* KlarDebug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEVELOPMENT_TEAM = "";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				INFOPLIST_FILE = BlockzillaTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.3;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = org.mozilla.ios.BlockzillaTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Firefox Focus.app/Firefox Focus";
+			};
+			name = KlarDebug;
+		};
+		E4F7F3F81E9C5D9200BAAB05 /* FocusDebug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = "";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				INFOPLIST_FILE = BlockzillaTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.3;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = org.mozilla.ios.BlockzillaTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SDKROOT = iphoneos;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 3.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Firefox Focus.app/Firefox Focus";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = FocusDebug;
+		};
+		E4F7F3F91E9C5D9200BAAB05 /* KlarRelease */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = "";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				INFOPLIST_FILE = BlockzillaTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.3;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = org.mozilla.ios.BlockzillaTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SDKROOT = iphoneos;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 3.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Firefox Focus.app/Firefox Focus";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = KlarRelease;
+		};
+		E4F7F3FA1E9C5D9200BAAB05 /* FocusRelease */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = "";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				INFOPLIST_FILE = BlockzillaTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.3;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = org.mozilla.ios.BlockzillaTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SDKROOT = iphoneos;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 3.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Firefox Focus.app/Firefox Focus";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = FocusRelease;
+		};
+		E4F7F3FB1E9C5D9200BAAB05 /* FocusEnterprise */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = "";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				INFOPLIST_FILE = BlockzillaTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.3;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = org.mozilla.ios.BlockzillaTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SDKROOT = iphoneos;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 3.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Firefox Focus.app/Firefox Focus";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = FocusEnterprise;
+		};
+		E4F7F3FC1E9C5D9200BAAB05 /* KlarEnterprise */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = "";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				INFOPLIST_FILE = BlockzillaTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.3;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = org.mozilla.ios.BlockzillaTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SDKROOT = iphoneos;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 3.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Firefox Focus.app/Firefox Focus";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = KlarEnterprise;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -2609,6 +3005,18 @@
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = FocusRelease;
+		};
+		E4F7F3FD1E9C5D9200BAAB05 /* Build configuration list for PBXNativeTarget "BlockzillaTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E4F7F3F71E9C5D9200BAAB05 /* KlarDebug */,
+				E4F7F3F81E9C5D9200BAAB05 /* FocusDebug */,
+				E4F7F3F91E9C5D9200BAAB05 /* KlarRelease */,
+				E4F7F3FA1E9C5D9200BAAB05 /* FocusRelease */,
+				E4F7F3FB1E9C5D9200BAAB05 /* FocusEnterprise */,
+				E4F7F3FC1E9C5D9200BAAB05 /* KlarEnterprise */,
+			);
+			defaultConfigurationIsVisible = 0;
 		};
 /* End XCConfigurationList section */
 	};

--- a/Blockzilla.xcodeproj/xcshareddata/xcschemes/Focus (Enterprise).xcscheme
+++ b/Blockzilla.xcodeproj/xcshareddata/xcschemes/Focus (Enterprise).xcscheme
@@ -42,6 +42,16 @@
                referenceType = "1">
             </LocationScenarioReference>
          </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "E4F7F3EF1E9C5D9200BAAB05"
+               BuildableName = "BlockzillaTests.xctest"
+               BlueprintName = "BlockzillaTests"
+               ReferencedContainer = "container:Blockzilla.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
       <MacroExpansion>
          <BuildableReference
@@ -64,9 +74,7 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
-      allowLocationSimulation = "NO"
-      language = "en"
-      region = "US">
+      allowLocationSimulation = "NO">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">
          <BuildableReference

--- a/Blockzilla.xcodeproj/xcshareddata/xcschemes/Focus.xcscheme
+++ b/Blockzilla.xcodeproj/xcshareddata/xcschemes/Focus.xcscheme
@@ -23,7 +23,7 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
-      buildConfiguration = "FocusRelease"
+      buildConfiguration = "FocusDebug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
@@ -35,6 +35,16 @@
                BlueprintIdentifier = "0BA39A821DD2B8E4005F970A"
                BuildableName = "XCUITest.xctest"
                BlueprintName = "XCUITest"
+               ReferencedContainer = "container:Blockzilla.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "E4F7F3EF1E9C5D9200BAAB05"
+               BuildableName = "BlockzillaTests.xctest"
+               BlueprintName = "BlockzillaTests"
                ReferencedContainer = "container:Blockzilla.xcodeproj">
             </BuildableReference>
          </TestableReference>
@@ -52,7 +62,7 @@
       </AdditionalOptions>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "FocusRelease"
+      buildConfiguration = "FocusDebug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
@@ -92,7 +102,7 @@
       </BuildableProductRunnable>
    </ProfileAction>
    <AnalyzeAction
-      buildConfiguration = "FocusRelease">
+      buildConfiguration = "FocusDebug">
    </AnalyzeAction>
    <ArchiveAction
       buildConfiguration = "FocusRelease"

--- a/Blockzilla.xcodeproj/xcshareddata/xcschemes/Klar (Enterprise).xcscheme
+++ b/Blockzilla.xcodeproj/xcshareddata/xcschemes/Klar (Enterprise).xcscheme
@@ -38,6 +38,16 @@
                ReferencedContainer = "container:Blockzilla.xcodeproj">
             </BuildableReference>
          </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "E4F7F3EF1E9C5D9200BAAB05"
+               BuildableName = "BlockzillaTests.xctest"
+               BlueprintName = "BlockzillaTests"
+               ReferencedContainer = "container:Blockzilla.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
       <MacroExpansion>
          <BuildableReference
@@ -60,8 +70,7 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
-      allowLocationSimulation = "YES"
-      language = "de">
+      allowLocationSimulation = "YES">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">
          <BuildableReference

--- a/Blockzilla.xcodeproj/xcshareddata/xcschemes/Klar.xcscheme
+++ b/Blockzilla.xcodeproj/xcshareddata/xcschemes/Klar.xcscheme
@@ -23,7 +23,7 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
-      buildConfiguration = "KlarRelease"
+      buildConfiguration = "KlarDebug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
@@ -35,6 +35,16 @@
                BlueprintIdentifier = "0BA39A821DD2B8E4005F970A"
                BuildableName = "XCUITest.xctest"
                BlueprintName = "XCUITest"
+               ReferencedContainer = "container:Blockzilla.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "E4F7F3EF1E9C5D9200BAAB05"
+               BuildableName = "BlockzillaTests.xctest"
+               BlueprintName = "BlockzillaTests"
                ReferencedContainer = "container:Blockzilla.xcodeproj">
             </BuildableReference>
          </TestableReference>
@@ -52,7 +62,7 @@
       </AdditionalOptions>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "KlarRelease"
+      buildConfiguration = "KlarDebug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
@@ -92,7 +102,7 @@
       </BuildableProductRunnable>
    </ProfileAction>
    <AnalyzeAction
-      buildConfiguration = "KlarRelease">
+      buildConfiguration = "KlarDebug">
    </AnalyzeAction>
    <ArchiveAction
       buildConfiguration = "KlarRelease"

--- a/Blockzilla.xcodeproj/xcshareddata/xcschemes/KlarMarketingTests.xcscheme
+++ b/Blockzilla.xcodeproj/xcshareddata/xcschemes/KlarMarketingTests.xcscheme
@@ -65,8 +65,7 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
-      allowLocationSimulation = "YES"
-      language = "de">
+      allowLocationSimulation = "YES">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">
          <BuildableReference

--- a/Blockzilla.xcodeproj/xcshareddata/xcschemes/KlarSnapshotTests.xcscheme
+++ b/Blockzilla.xcodeproj/xcshareddata/xcschemes/KlarSnapshotTests.xcscheme
@@ -65,8 +65,7 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
-      allowLocationSimulation = "YES"
-      language = "de">
+      allowLocationSimulation = "YES">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">
          <BuildableReference

--- a/Blockzilla/AboutViewController.swift
+++ b/Blockzilla/AboutViewController.swift
@@ -85,9 +85,10 @@ class AboutViewController: UIViewController, UITableViewDataSource, UITableViewD
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         switch (indexPath as NSIndexPath).row {
         case 1:
-            let url = URL(string: "https://support.mozilla.org/\(AppInfo.config.supportPath)")!
-            let contentViewController = AboutContentViewController(url: url)
-            navigationController?.pushViewController(contentViewController, animated: true)
+            if let url = SupportUtils.URLForTopic(AppInfo.config.supportTopic) {
+                let contentViewController = AboutContentViewController(url: url)
+                navigationController?.pushViewController(contentViewController, animated: true)
+            }
         case 2:
             let url = LocalWebServer.sharedInstance.URLForPath("/\(AppInfo.config.rightsFile)")!
             let contentViewController = AboutContentViewController(url: url)

--- a/Blockzilla/SettingsViewController.swift
+++ b/Blockzilla/SettingsViewController.swift
@@ -247,9 +247,10 @@ class SettingsViewController: UIViewController, UITableViewDataSource, UITableVi
             searchSettingsViewController.delegate = self
             navigationController?.pushViewController(searchSettingsViewController, animated: true)
         case 5:
-            guard let url = SupportUtils.URLForTopic(topic: "usage-data") else { break }
-            let contentViewController = AboutContentViewController(url: url)
-            navigationController?.pushViewController(contentViewController, animated: true)
+            if let url = SupportUtils.URLForTopic(.usageData) {
+                let contentViewController = AboutContentViewController(url: url)
+                navigationController?.pushViewController(contentViewController, animated: true)
+            }
         default: break
         }
     }

--- a/Blockzilla/SupportUtils.swift
+++ b/Blockzilla/SupportUtils.swift
@@ -4,17 +4,75 @@
 
 import Foundation
 
+public enum SupportTopic: String {
+    case focusHelp = "focus"
+    case klarHelp = "klar"
+    case usageData = "usage-data"
+
+    /// These are the additional supported languages, next to the default language the document is written in. At
+    /// some later stage SUMO will do an automatic redirect based on the Accepts-Language header. For now we will
+    /// have to maintain a static list of supported languages.
+
+    var supportedLanguages: Set<String> {
+        switch self {
+        case .focusHelp:
+            return Set(["es", "fr", "hi-in", "id", "it", "jp", "pl", "pt", "ru", "zh-tw"])
+        case .klarHelp:
+            return Set()
+        case .usageData:
+            return Set(["de", "es", "fr", "hi-in", "id", "it", "jp", "pl", "pt", "ru", "zh-tw"])
+        }
+    }
+
+    var slug: String {
+        return self.rawValue
+    }
+
+    /// Return a URL to this topic for the given language. The logic here is as follows: try to find the best matching
+    /// language code that this topic supports. And fall back to the default if no match is found. The default language
+    /// is silent, and is not added to the URL.
+
+    func URLForLanguageCode(_ languageCode: String) -> URL? {
+        if let matchingLanguageCode = matchPreferredLanguageToSupportedLanguages(languageCode.lowercased()) {
+            return URL(string: "https://support.mozilla.org/kb/\(slug)-\(matchingLanguageCode)")
+        } else {
+            return URL(string: "https://support.mozilla.org/kb/\(slug)")
+        }
+    }
+
+    /// Given a preferred language code, find the best match for this topic's supported languages. Returns nil if no
+    /// match can be found.
+
+    private func matchPreferredLanguageToSupportedLanguages(_ preferredLanguage: String) -> String? {
+        // 1. Try a direct match (es against es, zh-TW against zh-tw)
+        if supportedLanguages.contains(preferredLanguage) {
+            return preferredLanguage
+        }
+
+        // 2. Try to match the simplified preferred language against the supported languages (es-MX against es)
+        if preferredLanguage.contains("-") {
+            if let language = preferredLanguage.components(separatedBy: "-").first, supportedLanguages.contains(language) {
+                return language
+            }
+        }
+
+        // 3. Try to match the simplified preferred language against the simplified supported languages (hi against hi-in)
+        if !preferredLanguage.contains("-") {
+            for supportedLanguage in supportedLanguages {
+                if let language  = supportedLanguage.components(separatedBy: "-").first, preferredLanguage == language {
+                    return supportedLanguage
+                }
+            }
+        }
+
+        return nil
+    }
+}
+
 /// Utility functions related to SUMO.
 public struct SupportUtils {
-    /// Construct a NSURL pointing to a specific topic on SUMO. The topic should be a non-escaped string. It will
-    /// be properly escaped by this function.
-    ///
-    /// The resulting NSURL will include the app version, operating system and locale code. For example, a topic
-    /// "cheese" will be turned into a link that looks like https://support.mozilla.org/1/mobile/2.0/iOS/en-US/cheese
-    public static func URLForTopic(topic: String) -> URL? {
-        guard let escapedTopic = topic.addingPercentEncoding(withAllowedCharacters: CharacterSet.urlPathAllowed), let languageIdentifier = Locale.preferredLanguages.first else {
-            return nil
-        }
-        return URL(string: "https://support.mozilla.org/1/mobile/\(AppInfo.shortVersion)/iOS/\(languageIdentifier)/\(escapedTopic)")
+    /// Return a SUMO URL for the given topic.
+    public static func URLForTopic(_ topic: SupportTopic) -> URL? {
+        return topic.URLForLanguageCode(Locale.preferredLanguages.first ?? "en")
     }
 }

--- a/BlockzillaTests/BlockzillaTests.swift
+++ b/BlockzillaTests/BlockzillaTests.swift
@@ -1,0 +1,22 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import XCTest
+
+class BlockzillaTests: XCTestCase {
+    func testSupportUtilsURLForTopic() {
+        // focusHelp - No German
+        XCTAssertEqual(SupportTopic.focusHelp.URLForLanguageCode("en"), URL(string: "https://support.mozilla.org/kb/focus"))          // Default
+        XCTAssertEqual(SupportTopic.focusHelp.URLForLanguageCode("de"), URL(string: "https://support.mozilla.org/kb/focus"))          // Default
+        XCTAssertEqual(SupportTopic.focusHelp.URLForLanguageCode("es"), URL(string: "https://support.mozilla.org/kb/focus-es"))       // Simple
+        XCTAssertEqual(SupportTopic.focusHelp.URLForLanguageCode("es-MX"), URL(string: "https://support.mozilla.org/kb/focus-es"))    // Language-Region
+        XCTAssertEqual(SupportTopic.focusHelp.URLForLanguageCode("hi"), URL(string: "https://support.mozilla.org/kb/focus-hi-in"))    // Language-Region
+        XCTAssertEqual(SupportTopic.focusHelp.URLForLanguageCode("zh-TW"), URL(string: "https://support.mozilla.org/kb/focus-zh-tw")) // Language-Region
+
+        // klarHelp - Only German
+        XCTAssertEqual(SupportTopic.klarHelp.URLForLanguageCode("de"), URL(string: "https://support.mozilla.org/kb/klar"))
+        XCTAssertEqual(SupportTopic.klarHelp.URLForLanguageCode("de-CH"), URL(string: "https://support.mozilla.org/kb/klar"))
+        XCTAssertEqual(SupportTopic.klarHelp.URLForLanguageCode("en"), URL(string: "https://support.mozilla.org/kb/klar"))
+    }
+}

--- a/BlockzillaTests/Info.plist
+++ b/BlockzillaTests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/Shared/AppConfig.swift
+++ b/Shared/AppConfig.swift
@@ -10,7 +10,7 @@ protocol AppConfig {
     var firefoxAppStoreURL: URL { get }
     var productName: String { get }
     var rightsFile: String { get }
-    var supportPath: String { get }
+    var supportTopic: SupportTopic { get }
     var wordmark: UIImage { get }
 }
 
@@ -19,7 +19,7 @@ struct FocusAppConfig: AppConfig {
     let firefoxAppStoreURL = URL(string: "https://app.adjust.com/gs1ao4")!
     let productName = "Focus"
     let rightsFile = "rights-focus.html"
-    let supportPath = "en-US/kb/focus"
+    let supportTopic = SupportTopic.focusHelp
     let wordmark = #imageLiteral(resourceName: "img_focus_wordmark")
 }
 
@@ -28,6 +28,6 @@ struct KlarAppConfig: AppConfig {
     let firefoxAppStoreURL = URL(string: "https://app.adjust.com/c04cts")!
     let productName = "Klar"
     let rightsFile = "rights-klar.html"
-    let supportPath = "products/klar"
+    let supportTopic = SupportTopic.klarHelp
     let wordmark = #imageLiteral(resourceName: "img_klar_wordmark")
 }


### PR DESCRIPTION
This replaces `SupportUtils.URLForTopic()` with a new implementation that looks up support topics and their supported languages in a pre-defined list. This is a temporary measure until SUMO can look at the `Accept-Language` header and do this server side.

This PR also includes a test to make sure the selection of the right localized SUMO article is handled correctly.