### PR TITLE
Bug 1375249 - Use Debug config for test/run/analyze.

### DIFF
--- a/Blockzilla.xcodeproj/xcshareddata/xcschemes/Focus.xcscheme
+++ b/Blockzilla.xcodeproj/xcshareddata/xcschemes/Focus.xcscheme
@@ -23,7 +23,7 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
-      buildConfiguration = "FocusRelease"
+      buildConfiguration = "FocusDebug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
@@ -52,7 +52,7 @@
       </AdditionalOptions>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "FocusRelease"
+      buildConfiguration = "FocusDebug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
@@ -92,7 +92,7 @@
       </BuildableProductRunnable>
    </ProfileAction>
    <AnalyzeAction
-      buildConfiguration = "FocusRelease">
+      buildConfiguration = "FocusDebug">
    </AnalyzeAction>
    <ArchiveAction
       buildConfiguration = "FocusRelease"

--- a/Blockzilla.xcodeproj/xcshareddata/xcschemes/Klar.xcscheme
+++ b/Blockzilla.xcodeproj/xcshareddata/xcschemes/Klar.xcscheme
@@ -23,7 +23,7 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
-      buildConfiguration = "KlarRelease"
+      buildConfiguration = "KlarDebug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
@@ -52,7 +52,7 @@
       </AdditionalOptions>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "KlarRelease"
+      buildConfiguration = "KlarDebug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
@@ -92,7 +92,7 @@
       </BuildableProductRunnable>
    </ProfileAction>
    <AnalyzeAction
-      buildConfiguration = "KlarRelease">
+      buildConfiguration = "KlarDebug">
    </AnalyzeAction>
    <ArchiveAction
       buildConfiguration = "KlarRelease"


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1375249

I don't actually know build configs that well so concerns:
- I only assume Profile should be a release config.
- Analyze is a Debug config because *SnapshotTests set it as Debug config.
- I assume we should only change Focus/Klar, which are intended for local
builds and we should leave *Tests & *Enterprise as is.